### PR TITLE
Compile to Java 1.7 binary

### DIFF
--- a/google-oauth-client-appengine/pom.xml
+++ b/google-oauth-client-appengine/pom.xml
@@ -15,7 +15,7 @@
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <links>
-            <link>http://download.oracle.com/javase/6/docs/api/</link>
+            <link>http://download.oracle.com/javase/7/docs/api/</link>
             <link>http://code.google.com/appengine/docs/java/javadoc</link>
             <link>https://googleapis.github.io/google-http-java-client/releases/${project.http.version}/javadoc/</link>
           </links>

--- a/google-oauth-client-java6/pom.xml
+++ b/google-oauth-client-java6/pom.xml
@@ -15,7 +15,7 @@
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <links>
-            <link>http://download.oracle.com/javase/6/docs/api/</link>
+            <link>http://download.oracle.com/javase/7/docs/api/</link>
             <link>https://googleapis.github.io/google-http-java-client/releases/${project.http.version}/javadoc/</link>
           </links>
           <doctitle>${project.name} ${project.version}</doctitle>
@@ -44,14 +44,14 @@
           </execution>
         </executions>
       </plugin>
-      <!--Set minimum version to Java 6-->
+      <!--Set minimum version to Java 7-->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>animal-sniffer-maven-plugin</artifactId>
         <configuration>
           <signature>
             <groupId>org.codehaus.mojo.signature</groupId>
-            <artifactId>java16</artifactId>
+            <artifactId>java17</artifactId>
             <version>1.0</version>
           </signature>
         </configuration>

--- a/google-oauth-client-jetty/pom.xml
+++ b/google-oauth-client-jetty/pom.xml
@@ -15,7 +15,7 @@
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <links>
-            <link>http://download.oracle.com/javase/6/docs/api/</link>
+            <link>http://download.oracle.com/javase/7/docs/api/</link>
             <link>https://googleapis.github.io/google-http-java-client/releases/${project.http.version}/javadoc/</link>
           </links>
           <doctitle>${project.name} ${project.version}</doctitle>
@@ -44,14 +44,14 @@
           </execution>
         </executions>
       </plugin>
-      <!--Minimum version is Java 6 due to dependency on java6 package-->
+      <!--Minimum version is Java 7 -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>animal-sniffer-maven-plugin</artifactId>
         <configuration>
           <signature>
             <groupId>org.codehaus.mojo.signature</groupId>
-            <artifactId>java16</artifactId>
+            <artifactId>java17</artifactId>
             <version>1.0</version>
           </signature>
         </configuration>

--- a/google-oauth-client-servlet/pom.xml
+++ b/google-oauth-client-servlet/pom.xml
@@ -15,7 +15,7 @@
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <links>
-            <link>http://download.oracle.com/javase/6/docs/api/</link>
+            <link>http://download.oracle.com/javase/7/docs/api/</link>
             <link>http://code.google.com/appengine/docs/java/javadoc</link>
             <link>https://googleapis.github.io/google-http-java-client/releases/${project.http.version}/javadoc/</link>
           </links>

--- a/google-oauth-client/pom.xml
+++ b/google-oauth-client/pom.xml
@@ -20,7 +20,7 @@
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <links>
-            <link>http://download.oracle.com/javase/6/docs/api/</link>
+            <link>http://download.oracle.com/javase/7/docs/api/</link>
             <link>https://googleapis.github.io/google-http-java-client/releases/${project.http.version}/javadoc/</link>
           </links>
           <doctitle>${project.name} ${project.version}</doctitle>

--- a/pom.xml
+++ b/pom.xml
@@ -220,8 +220,8 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>2.3.2</version>
           <configuration>
-            <source>1.6</source>
-            <target>1.6</target>
+            <source>1.7</source>
+            <target>1.7</target>
           </configuration>
         </plugin>
         <plugin>
@@ -311,7 +311,7 @@
             <phase>site</phase>
             <configuration>
               <links>
-                <link>http://docs.oracle.com/javase/6/docs/api/</link>
+                <link>http://docs.oracle.com/javase/7/docs/api/</link>
                 <link>http://cloud.google.com/appengine/docs/java/javadoc</link>
                 <link>https://googleapis.github.io/google-http-java-client/releases/${project.http.version}/javadoc/</link>
               </links>
@@ -396,7 +396,7 @@
         <configuration>
           <signature>
             <groupId>org.codehaus.mojo.signature</groupId>
-            <artifactId>java16</artifactId>
+            <artifactId>java17</artifactId>
             <version>1.0</version>
           </signature>
         </configuration>


### PR DESCRIPTION
We're dropping Java 6 in the next release, so set the maven-compiler to use source level 1.7 and to compile to 1.7 binary. Also update animal-sniffer-plugin to java17 to allow 1.7 source.
