### PR TITLE
Fix RequiredExecutionEnvironment setting in the OSGI metadata

### DIFF
--- a/google-oauth-client-java6/pom.xml
+++ b/google-oauth-client-java6/pom.xml
@@ -63,7 +63,7 @@
         <configuration>
           <instructions>
             <Bundle-SymbolicName>com.google.oauth-client-java6</Bundle-SymbolicName>
-            <Bundle-RequiredExecutionEnvironment>JavaSE-1.6</Bundle-RequiredExecutionEnvironment>
+            <Bundle-RequiredExecutionEnvironment>JavaSE-1.7</Bundle-RequiredExecutionEnvironment>
           </instructions>
         </configuration>
         <executions>

--- a/google-oauth-client-jetty/pom.xml
+++ b/google-oauth-client-jetty/pom.xml
@@ -63,7 +63,7 @@
         <configuration>
           <instructions>
             <Bundle-SymbolicName>com.google.oauth-client-jetty</Bundle-SymbolicName>
-            <Bundle-RequiredExecutionEnvironment>JavaSE-1.6</Bundle-RequiredExecutionEnvironment>
+            <Bundle-RequiredExecutionEnvironment>JavaSE-1.7</Bundle-RequiredExecutionEnvironment>
           </instructions>
         </configuration>
         <executions>

--- a/google-oauth-client-servlet/pom.xml
+++ b/google-oauth-client-servlet/pom.xml
@@ -89,7 +89,7 @@
         <configuration>
           <instructions>
             <Bundle-SymbolicName>com.google.oauth-client-servlet</Bundle-SymbolicName>
-            <Bundle-RequiredExecutionEnvironment>JavaSE-1.6</Bundle-RequiredExecutionEnvironment>
+            <Bundle-RequiredExecutionEnvironment>JavaSE-1.7</Bundle-RequiredExecutionEnvironment>
           </instructions>
         </configuration>
         <executions>

--- a/google-oauth-client/pom.xml
+++ b/google-oauth-client/pom.xml
@@ -56,7 +56,7 @@
         <configuration>
           <instructions>
             <Bundle-SymbolicName>com.google.oauth-client</Bundle-SymbolicName>
-            <Bundle-RequiredExecutionEnvironment>JavaSE-1.6</Bundle-RequiredExecutionEnvironment>
+            <Bundle-RequiredExecutionEnvironment>JavaSE-1.7</Bundle-RequiredExecutionEnvironment>
           </instructions>
         </configuration>
         <executions>


### PR DESCRIPTION
We are bumping the required Java version to 1.7 in the 1.28.0 (next) release.