### PR TITLE
Release google-oauth-java-client v1.28.0

### DIFF
--- a/.kokoro/release/drop.sh
+++ b/.kokoro/release/drop.sh
@@ -15,11 +15,18 @@
 
 set -eo pipefail
 
-source $(dirname "$0")/common.sh
+# STAGING_REPOSITORY_ID must be set
+if [ -z "${STAGING_REPOSITORY_ID}" ]; then
+  echo "Missing STAGING_REPOSITORY_ID environment variable"
+  exit 1
+fi
 
+source $(dirname "$0")/common.sh
 pushd $(dirname "$0")/../../
 
 setup_environment_secrets
 create_settings_xml_file "settings.xml"
 
-mvn nexus-staging:drop --settings=settings.xml
+mvn nexus-staging:drop -B \
+  --settings=settings.xml \
+  -DstagingRepositoryId=${STAGING_REPOSITORY_ID}

--- a/.kokoro/release/promote.sh
+++ b/.kokoro/release/promote.sh
@@ -15,6 +15,12 @@
 
 set -eo pipefail
 
+# STAGING_REPOSITORY_ID must be set
+if [ -z "${STAGING_REPOSITORY_ID}" ]; then
+  echo "Missing STAGING_REPOSITORY_ID environment variable"
+  exit 1
+fi
+
 source $(dirname "$0")/common.sh
 
 pushd $(dirname "$0")/../../
@@ -22,4 +28,7 @@ pushd $(dirname "$0")/../../
 setup_environment_secrets
 create_settings_xml_file "settings.xml"
 
-mvn nexus-staging:release -DperformRelease=true --settings=settings.xml
+mvn nexus-staging:release -B \
+  -DperformRelease=true \
+  --settings=settings.xml \
+  -DstagingRepositoryId=${STAGING_REPOSITORY_ID}

--- a/google-oauth-client-appengine/pom.xml
+++ b/google-oauth-client-appengine/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.oauth-client</groupId>
     <artifactId>google-oauth-client-parent</artifactId>
-    <version>1.27.1-SNAPSHOT</version><!-- {x-version-update:google-oauth-client:current} -->
+    <version>1.28.0</version><!-- {x-version-update:google-oauth-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-oauth-client-appengine</artifactId>

--- a/google-oauth-client-assembly/pom.xml
+++ b/google-oauth-client-assembly/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.oauth-client</groupId>
     <artifactId>google-oauth-client-parent</artifactId>
-    <version>1.27.1-SNAPSHOT</version><!-- {x-version-update:google-oauth-client:current} -->
+    <version>1.28.0</version><!-- {x-version-update:google-oauth-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <groupId>com.google.oauth-client</groupId>

--- a/google-oauth-client-bom/README.md
+++ b/google-oauth-client-bom/README.md
@@ -12,7 +12,7 @@ To use it in Maven, add the following to your `pom.xml`:
     <dependency>
       <groupId>com.google.oauth-client</groupId>
       <artifactId>google-oauth-client-bom</artifactId>
-      <version>1.27.0</version>
+      <version>1.28.0</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>

--- a/google-oauth-client-bom/pom.xml
+++ b/google-oauth-client-bom/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.oauth-client</groupId>
   <artifactId>google-oauth-client-bom</artifactId>
-  <version>1.27.1-SNAPSHOT</version><!-- {x-version-update:google-oauth-client:current} -->
+  <version>1.28.0</version><!-- {x-version-update:google-oauth-client:current} -->
   <packaging>pom</packaging>
 
   <name>Google OAuth Client Library for Java BOM</name>
@@ -63,32 +63,32 @@
       <dependency>
         <groupId>com.google.oauth-client</groupId>
         <artifactId>google-oauth-client</artifactId>
-        <version>1.27.1-SNAPSHOT</version><!-- {x-version-update:google-oauth-client:current} -->
+        <version>1.28.0</version><!-- {x-version-update:google-oauth-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.oauth-client</groupId>
         <artifactId>google-oauth-client-appengine</artifactId>
-        <version>1.27.1-SNAPSHOT</version><!-- {x-version-update:google-oauth-client:current} -->
+        <version>1.28.0</version><!-- {x-version-update:google-oauth-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.oauth-client</groupId>
         <artifactId>google-oauth-client-assembly</artifactId>
-        <version>1.27.1-SNAPSHOT</version><!-- {x-version-update:google-oauth-client:current} -->
+        <version>1.28.0</version><!-- {x-version-update:google-oauth-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.oauth-client</groupId>
         <artifactId>google-oauth-client-java6</artifactId>
-        <version>1.27.1-SNAPSHOT</version><!-- {x-version-update:google-oauth-client:current} -->
+        <version>1.28.0</version><!-- {x-version-update:google-oauth-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.oauth-client</groupId>
         <artifactId>google-oauth-client-jetty</artifactId>
-        <version>1.27.1-SNAPSHOT</version><!-- {x-version-update:google-oauth-client:current} -->
+        <version>1.28.0</version><!-- {x-version-update:google-oauth-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.oauth-client</groupId>
         <artifactId>google-oauth-client-servlet</artifactId>
-        <version>1.27.1-SNAPSHOT</version><!-- {x-version-update:google-oauth-client:current} -->
+        <version>1.28.0</version><!-- {x-version-update:google-oauth-client:current} -->
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/google-oauth-client-java6/pom.xml
+++ b/google-oauth-client-java6/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.oauth-client</groupId>
     <artifactId>google-oauth-client-parent</artifactId>
-    <version>1.27.1-SNAPSHOT</version><!-- {x-version-update:google-oauth-client:current} -->
+    <version>1.28.0</version><!-- {x-version-update:google-oauth-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-oauth-client-java6</artifactId>

--- a/google-oauth-client-jetty/pom.xml
+++ b/google-oauth-client-jetty/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.oauth-client</groupId>
     <artifactId>google-oauth-client-parent</artifactId>
-    <version>1.27.1-SNAPSHOT</version><!-- {x-version-update:google-oauth-client:current} -->
+    <version>1.28.0</version><!-- {x-version-update:google-oauth-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-oauth-client-jetty</artifactId>

--- a/google-oauth-client-servlet/pom.xml
+++ b/google-oauth-client-servlet/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.oauth-client</groupId>
     <artifactId>google-oauth-client-parent</artifactId>
-    <version>1.27.1-SNAPSHOT</version><!-- {x-version-update:google-oauth-client:current} -->
+    <version>1.28.0</version><!-- {x-version-update:google-oauth-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-oauth-client-servlet</artifactId>

--- a/google-oauth-client/pom.xml
+++ b/google-oauth-client/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.oauth-client</groupId>
     <artifactId>google-oauth-client-parent</artifactId>
-    <version>1.27.1-SNAPSHOT</version><!-- {x-version-update:google-oauth-client:current} -->
+    <version>1.28.0</version><!-- {x-version-update:google-oauth-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-oauth-client</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -264,7 +264,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.19.1</version>
+          <version>3.0.0-M3</version>
           <configuration>
             <argLine>-Xmx1024m</argLine>
             <reportNameSuffix>sponge_log</reportNameSuffix>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
   <groupId>com.google.oauth-client</groupId>
   <artifactId>google-oauth-client-parent</artifactId>
-  <version>1.27.1-SNAPSHOT</version><!-- {x-version-update:google-oauth-client:current} -->
+  <version>1.28.0</version><!-- {x-version-update:google-oauth-client:current} -->
   <packaging>pom</packaging>
   <name>Parent for the Google OAuth Client Library for Java</name>
 
@@ -426,7 +426,7 @@
     -->
     <project.appengine.version>1.9.64</project.appengine.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <project.http.version>1.27.0</project.http.version><!-- {x-version-update:google-http-client:released} -->
+    <project.http.version>1.28.0</project.http.version><!-- {x-version-update:google-http-client:released} -->
     <project.jsr305.version>3.0.2</project.jsr305.version>
     <project.gson.version>2.1</project.gson.version>
     <project.jackson-core-asl.version>1.9.13</project.jackson-core-asl.version>

--- a/samples/dailymotion-cmdline-sample/pom.xml
+++ b/samples/dailymotion-cmdline-sample/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.oauth-client</groupId>
     <artifactId>google-oauth-client-parent</artifactId>
-    <version>1.27.1-SNAPSHOT</version><!-- {x-version-update:google-oauth-client:current} -->
+    <version>1.28.0</version><!-- {x-version-update:google-oauth-client:current} -->
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>dailymotion-simple-cmdline-sample</artifactId>

--- a/versions.txt
+++ b/versions.txt
@@ -1,5 +1,5 @@
 # Format:
 # module:released-version:current-version
 
-google-oauth-client:1.27.0:1.27.1-SNAPSHOT
-google-http-client:1.27.0:1.27.1-SNAPSHOT
+google-oauth-client:1.28.0:1.28.0
+google-http-client:1.28.0:1.28.0


### PR DESCRIPTION
This pull request was generated using releasetool.

01-07-2019 13:34 PST

### Breaking Changes
- Java 6 support was dropped ([#238](https://github.com/google/google-oauth-java-client/pull/238))

### Implementation Changes
- Fix RequiredExecutionEnvironment setting in the OSGI metadata ([#240](https://github.com/google/google-oauth-java-client/pull/240))

### New Features
- Add Java 11 test configs ([#239](https://github.com/google/google-oauth-java-client/pull/239))

### Deprecations
- Add deprecation annotation for code scheduled for deprecation ([#241](https://github.com/google/google-oauth-java-client/pull/241))

### Dependencies
- Update commons-codec 1.6 -> 1.11 ([#242](https://github.com/google/google-oauth-java-client/pull/242))
- Update guava to 26.0-android ([#237](https://github.com/google/google-oauth-java-client/pull/237))

### Internal / Testing Changes
- Bump next snapshot ([#236](https://github.com/google/google-oauth-java-client/pull/236))