### PR TITLE
Update javadoc links to point to googleapis.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,16 +12,16 @@ problems.
 Written by Google, the Google OAuth Client Library for Java is a powerful and easy-to-use Java
 library for the OAuth 1.0a and OAuth 2.0 authorization standards. The Google OAuth Client Library
 for Java is designed to work with any OAuth service on the web, not just with Google APIs. It is
-built on the [Google HTTP Client Library for Java](https://github.com/google/google-http-java-client).
+built on the [Google HTTP Client Library for Java](https://github.com/googleapis/google-http-java-client).
 
 The library supports the following Java environments:
 
-- Java 6 (or higher)
+- Java 7 (or higher)
 - Android 4.0 (Ice Cream Sandwich) (or higher)
 - Google App Engine
 
 For access to Google APIs, see the
-[Google APIs Client Library for Java](https://github.com/google/google-api-java-client).
+[Google APIs Client Library for Java](https://github.com/googleapis/google-api-java-client).
 
 This is an open-source library, and
 [contributions](https://developers.google.com/api-client-library/java/google-oauth-java-client/contribute)
@@ -32,8 +32,8 @@ are welcome.
 - [Developer's Guide](https://developers.google.com/api-client-library/java/google-oauth-java-client/)
 - [Setup Instructions](https://developers.google.com/api-client-library/java/google-oauth-java-client/setup)
 - [Samples](https://developers.google.com/api-client-library/java/google-oauth-java-client/samples)
-- [JavaDoc](https://developers.google.com/api-client-library/java/google-oauth-java-client/reference/index)
-- [Release Notes](https://developers.google.com/api-client-library/java/google-oauth-java-client/release-notes)
+- [JavaDoc](https://googleapis.dev/java/google-oauth-client/latest/)
+- [Release Notes](https://github.com/googleapis/google-oauth-java-client/releases)
 - [Support (Questions, Bugs)](https://developers.google.com/api-client-library/java/google-oauth-java-client/support)
 
 ## CI Status
@@ -47,15 +47,3 @@ Java 11 | [![Kokoro CI](http://storage.googleapis.com/cloud-devrel-public/java/b
 ## Links
 
 - [Discuss](http://groups.google.com/group/google-oauth-java-client)
-
-## Notice: Ending Java 6 Support
-
-Please note: since Java 6 extended support is being ended this December by Oracle, we will begin
-ending Java 6 support in early 2019, with release 1.28.0 as a tentative goal. Users may stay still
-use these libraries in Java 6 projects for some time, but going forward we will not ensure that
-these libraries work in such an environment. After 1.28.0, our supported versions will include Java
-7 and onward.
-
-For Android users, we will continue our 4.0 support.
-
-For questions or concerns, please file an issue in the GitHub repository.

--- a/google-oauth-client-appengine/pom.xml
+++ b/google-oauth-client-appengine/pom.xml
@@ -17,7 +17,7 @@
           <links>
             <link>http://download.oracle.com/javase/7/docs/api/</link>
             <link>http://code.google.com/appengine/docs/java/javadoc</link>
-            <link>https://googleapis.github.io/google-http-java-client/releases/${project.http.version}/javadoc/</link>
+            <link>https://googleapis.dev/java/google-http-client/${project.http.version}/</link>
           </links>
           <doctitle>${project.name} ${project.version}</doctitle>
           <windowtitle>${project.artifactId} ${project.version}</windowtitle>

--- a/google-oauth-client-java6/pom.xml
+++ b/google-oauth-client-java6/pom.xml
@@ -16,7 +16,7 @@
         <configuration>
           <links>
             <link>http://download.oracle.com/javase/7/docs/api/</link>
-            <link>https://googleapis.github.io/google-http-java-client/releases/${project.http.version}/javadoc/</link>
+            <link>https://googleapis.dev/java/google-http-client/${project.http.version}/</link>
           </links>
           <doctitle>${project.name} ${project.version}</doctitle>
           <windowtitle>${project.artifactId} ${project.version}</windowtitle>

--- a/google-oauth-client-jetty/pom.xml
+++ b/google-oauth-client-jetty/pom.xml
@@ -16,7 +16,7 @@
         <configuration>
           <links>
             <link>http://download.oracle.com/javase/7/docs/api/</link>
-            <link>https://googleapis.github.io/google-http-java-client/releases/${project.http.version}/javadoc/</link>
+            <link>https://googleapis.dev/java/google-http-client/${project.http.version}/</link>
           </links>
           <doctitle>${project.name} ${project.version}</doctitle>
           <windowtitle>${project.artifactId} ${project.version}</windowtitle>

--- a/google-oauth-client-servlet/pom.xml
+++ b/google-oauth-client-servlet/pom.xml
@@ -17,7 +17,7 @@
           <links>
             <link>http://download.oracle.com/javase/7/docs/api/</link>
             <link>http://code.google.com/appengine/docs/java/javadoc</link>
-            <link>https://googleapis.github.io/google-http-java-client/releases/${project.http.version}/javadoc/</link>
+            <link>https://googleapis.dev/java/google-http-client/${project.http.version}/</link>
           </links>
           <doctitle>${project.name} ${project.version}</doctitle>
           <windowtitle>${project.artifactId} ${project.version}</windowtitle>

--- a/google-oauth-client-servlet/pom.xml
+++ b/google-oauth-client-servlet/pom.xml
@@ -110,10 +110,6 @@
       <artifactId>google-oauth-client</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.http-client</groupId>
-      <artifactId>google-http-client-jdo</artifactId>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/google-oauth-client/pom.xml
+++ b/google-oauth-client/pom.xml
@@ -21,7 +21,7 @@
         <configuration>
           <links>
             <link>http://download.oracle.com/javase/7/docs/api/</link>
-            <link>https://googleapis.github.io/google-http-java-client/releases/${project.http.version}/javadoc/</link>
+            <link>https://googleapis.dev/java/google-http-client/${project.http.version}/</link>
           </links>
           <doctitle>${project.name} ${project.version}</doctitle>
           <windowtitle>${project.artifactId} ${project.version}</windowtitle>

--- a/pom.xml
+++ b/pom.xml
@@ -338,7 +338,7 @@
               <links>
                 <link>http://docs.oracle.com/javase/7/docs/api/</link>
                 <link>http://cloud.google.com/appengine/docs/java/javadoc</link>
-                <link>https://googleapis.github.io/google-http-java-client/releases/${project.http.version}/javadoc/</link>
+                <link>https://googleapis.dev/java/google-http-client/${project.http.version}/</link>
               </links>
               <doctitle>Google OAuth Client Library for Java ${project.version}</doctitle>
               <excludePackageNames>com.google.api.services</excludePackageNames>
@@ -464,7 +464,7 @@
     -->
     <project.appengine.version>1.9.64</project.appengine.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <project.http.version>1.28.0</project.http.version><!-- {x-version-update:google-http-client:released} -->
+    <project.http.version>1.29.1</project.http.version>
     <project.jsr305.version>3.0.2</project.jsr305.version>
     <project.gson.version>2.1</project.gson.version>
     <project.jackson-core-asl.version>1.9.13</project.jackson-core-asl.version>

--- a/versions.txt
+++ b/versions.txt
@@ -2,4 +2,3 @@
 # module:released-version:current-version
 
 google-oauth-client:1.28.0:1.28.1-SNAPSHOT
-google-http-client:1.28.0:1.28.1-SNAPSHOT


### PR DESCRIPTION
Also, stops version bumping the http version when releasing this library - that version bump should be explicit.