### PR TITLE
Release google-oauth-java-client v1.29.0

### DIFF
--- a/google-oauth-client-appengine/pom.xml
+++ b/google-oauth-client-appengine/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.oauth-client</groupId>
     <artifactId>google-oauth-client-parent</artifactId>
-    <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-oauth-client:current} -->
+    <version>1.29.0</version><!-- {x-version-update:google-oauth-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-oauth-client-appengine</artifactId>

--- a/google-oauth-client-assembly/pom.xml
+++ b/google-oauth-client-assembly/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.oauth-client</groupId>
     <artifactId>google-oauth-client-parent</artifactId>
-    <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-oauth-client:current} -->
+    <version>1.29.0</version><!-- {x-version-update:google-oauth-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <groupId>com.google.oauth-client</groupId>

--- a/google-oauth-client-bom/README.md
+++ b/google-oauth-client-bom/README.md
@@ -12,7 +12,7 @@ To use it in Maven, add the following to your `pom.xml`:
     <dependency>
       <groupId>com.google.oauth-client</groupId>
       <artifactId>google-oauth-client-bom</artifactId>
-      <version>1.28.0</version>
+      <version>1.29.0</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>

--- a/google-oauth-client-bom/pom.xml
+++ b/google-oauth-client-bom/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.oauth-client</groupId>
   <artifactId>google-oauth-client-bom</artifactId>
-  <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-oauth-client:current} -->
+  <version>1.29.0</version><!-- {x-version-update:google-oauth-client:current} -->
   <packaging>pom</packaging>
 
   <name>Google OAuth Client Library for Java BOM</name>
@@ -63,32 +63,32 @@
       <dependency>
         <groupId>com.google.oauth-client</groupId>
         <artifactId>google-oauth-client</artifactId>
-        <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-oauth-client:current} -->
+        <version>1.29.0</version><!-- {x-version-update:google-oauth-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.oauth-client</groupId>
         <artifactId>google-oauth-client-appengine</artifactId>
-        <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-oauth-client:current} -->
+        <version>1.29.0</version><!-- {x-version-update:google-oauth-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.oauth-client</groupId>
         <artifactId>google-oauth-client-assembly</artifactId>
-        <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-oauth-client:current} -->
+        <version>1.29.0</version><!-- {x-version-update:google-oauth-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.oauth-client</groupId>
         <artifactId>google-oauth-client-java6</artifactId>
-        <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-oauth-client:current} -->
+        <version>1.29.0</version><!-- {x-version-update:google-oauth-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.oauth-client</groupId>
         <artifactId>google-oauth-client-jetty</artifactId>
-        <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-oauth-client:current} -->
+        <version>1.29.0</version><!-- {x-version-update:google-oauth-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.oauth-client</groupId>
         <artifactId>google-oauth-client-servlet</artifactId>
-        <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-oauth-client:current} -->
+        <version>1.29.0</version><!-- {x-version-update:google-oauth-client:current} -->
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/google-oauth-client-java6/pom.xml
+++ b/google-oauth-client-java6/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.oauth-client</groupId>
     <artifactId>google-oauth-client-parent</artifactId>
-    <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-oauth-client:current} -->
+    <version>1.29.0</version><!-- {x-version-update:google-oauth-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-oauth-client-java6</artifactId>

--- a/google-oauth-client-jetty/pom.xml
+++ b/google-oauth-client-jetty/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.oauth-client</groupId>
     <artifactId>google-oauth-client-parent</artifactId>
-    <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-oauth-client:current} -->
+    <version>1.29.0</version><!-- {x-version-update:google-oauth-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-oauth-client-jetty</artifactId>

--- a/google-oauth-client-servlet/pom.xml
+++ b/google-oauth-client-servlet/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.oauth-client</groupId>
     <artifactId>google-oauth-client-parent</artifactId>
-    <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-oauth-client:current} -->
+    <version>1.29.0</version><!-- {x-version-update:google-oauth-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-oauth-client-servlet</artifactId>

--- a/google-oauth-client/pom.xml
+++ b/google-oauth-client/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.oauth-client</groupId>
     <artifactId>google-oauth-client-parent</artifactId>
-    <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-oauth-client:current} -->
+    <version>1.29.0</version><!-- {x-version-update:google-oauth-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-oauth-client</artifactId>

--- a/node_modules/ansi-colors/README.md
+++ b/node_modules/ansi-colors/README.md
@@ -1,0 +1,274 @@
+# ansi-colors [![NPM version](https://img.shields.io/npm/v/ansi-colors.svg?style=flat)](https://www.npmjs.com/package/ansi-colors) [![NPM monthly downloads](https://img.shields.io/npm/dm/ansi-colors.svg?style=flat)](https://npmjs.org/package/ansi-colors) [![NPM total downloads](https://img.shields.io/npm/dt/ansi-colors.svg?style=flat)](https://npmjs.org/package/ansi-colors) [![Linux Build Status](https://img.shields.io/travis/doowb/ansi-colors.svg?style=flat&label=Travis)](https://travis-ci.org/doowb/ansi-colors) [![Windows Build Status](https://img.shields.io/appveyor/ci/doowb/ansi-colors.svg?style=flat&label=AppVeyor)](https://ci.appveyor.com/project/doowb/ansi-colors)
+
+> Easily add ANSI colors to your text and symbols in the terminal. A faster drop-in replacement for chalk, kleur and turbocolor (without the dependencies and rendering bugs).
+
+Please consider following this project's author, [Brian Woodward](https://github.com/doowb), and consider starring the project to show your :heart: and support.
+
+## Install
+
+Install with [npm](https://www.npmjs.com/):
+
+```sh
+$ npm install --save ansi-colors
+```
+
+![image](https://user-images.githubusercontent.com/383994/39635445-8a98a3a6-4f8b-11e8-89c1-068c45d4fff8.png)
+
+## Why use this?
+
+ansi-colors is _the fastest Node.js library for terminal styling_. A more performant drop-in replacement for chalk, with no dependencies.
+
+* _Blazing fast_ - Fastest terminal styling library in node.js, 10-20x faster than chalk!
+
+* _Drop-in replacement_ for [chalk](https://github.com/chalk/chalk).
+* _No dependencies_ (Chalk has 7 dependencies in its tree!)
+
+* _Safe_ - Does not modify the `String.prototype` like [colors](https://github.com/Marak/colors.js).
+* Supports [nested colors](#nested-colors), **and does not have the [nested styling bug](#nested-styling-bug) that is present in [colorette](https://github.com/jorgebucaran/colorette), [chalk](https://github.com/chalk/chalk), and [kleur](https://github.com/lukeed/kleur)**.
+* Supports [chained colors](#chained-colors).
+* [Toggle color support](#toggle-color-support) on or off.
+
+## Usage
+
+```js
+const c = require('ansi-colors');
+
+console.log(c.red('This is a red string!'));
+console.log(c.green('This is a red string!'));
+console.log(c.cyan('This is a cyan string!'));
+console.log(c.yellow('This is a yellow string!'));
+```
+
+![image](https://user-images.githubusercontent.com/383994/39653848-a38e67da-4fc0-11e8-89ae-98c65ebe9dcf.png)
+
+## Chained colors
+
+```js
+console.log(c.bold.red('this is a bold red message'));
+console.log(c.bold.yellow.italic('this is a bold yellow italicized message'));
+console.log(c.green.bold.underline('this is a bold green underlined message'));
+```
+
+![image](https://user-images.githubusercontent.com/383994/39635780-7617246a-4f8c-11e8-89e9-05216cc54e38.png)
+
+## Nested colors
+
+```js
+console.log(c.yellow(`foo ${c.red.bold('red')} bar ${c.cyan('cyan')} baz`));
+```
+
+![image](https://user-images.githubusercontent.com/383994/39635817-8ed93d44-4f8c-11e8-8afd-8c3ea35f5fbe.png)
+
+### Nested styling bug
+
+`ansi-colors` does not have the nested styling bug found in [colorette](https://github.com/jorgebucaran/colorette), [chalk](https://github.com/chalk/chalk), and [kleur](https://github.com/lukeed/kleur).
+
+```js
+const { bold, red } = require('ansi-styles');
+console.log(bold(`foo ${red.dim('bar')} baz`));
+
+const colorette = require('colorette');
+console.log(colorette.bold(`foo ${colorette.red(colorette.dim('bar'))} baz`));
+
+const kleur = require('kleur');
+console.log(kleur.bold(`foo ${kleur.red.dim('bar')} baz`));
+
+const chalk = require('chalk');
+console.log(chalk.bold(`foo ${chalk.red.dim('bar')} baz`));
+```
+
+**Results in the following**
+
+(sans icons and labels)
+
+![image](https://user-images.githubusercontent.com/383994/47280326-d2ee0580-d5a3-11e8-9611-ea6010f0a253.png)
+
+## Toggle color support
+
+Easily enable/disable colors.
+
+```js
+const c = require('ansi-colors');
+
+// disable colors manually
+c.enabled = false;
+
+// or use a library to automatically detect support
+c.enabled = require('color-support').hasBasic;
+
+console.log(c.red('I will only be colored red if the terminal supports colors'));
+```
+
+## Strip ANSI codes
+
+Use the `.unstyle` method to strip ANSI codes from a string.
+
+```js
+console.log(c.unstyle(c.blue.bold('foo bar baz')));
+//=> 'foo bar baz'
+```
+
+## Available styles
+
+**Note** that bright and bright-background colors are not always supported.
+
+| Colors  | Background Colors | Bright Colors | Bright Background Colors |
+| ------- | ----------------- | ------------- | ------------------------ |
+| black   | bgBlack           | blackBright   | bgBlackBright            |
+| red     | bgRed             | redBright     | bgRedBright              |
+| green   | bgGreen           | greenBright   | bgGreenBright            |
+| yellow  | bgYellow          | yellowBright  | bgYellowBright           |
+| blue    | bgBlue            | blueBright    | bgBlueBright             |
+| magenta | bgMagenta         | magentaBright | bgMagentaBright          |
+| cyan    | bgCyan            | cyanBright    | bgCyanBright             |
+| white   | bgWhite           | whiteBright   | bgWhiteBright            |
+| gray    |                   |               |                          |
+| grey    |                   |               |                          |
+
+_(`gray` is the U.S. spelling, `grey` is more commonly used in the Canada and U.K.)_
+
+### Style modifiers
+
+* dim
+* **bold**
+
+* hidden
+* _italic_
+
+* underline
+* inverse
+* ~~strikethrough~~
+
+* reset
+
+## Performance
+
+**Libraries tested**
+
+* ansi-colors v3.0.4
+* chalk v2.4.1
+
+### Mac
+
+> MacBook Pro, Intel Core i7, 2.3 GHz, 16 GB.
+
+**Load time**
+
+Time it takes to load the first time `require()` is called:
+
+* ansi-colors - `1.915ms`
+* chalk - `12.437ms`
+
+**Benchmarks**
+
+```
+# All Colors
+  ansi-colors x 173,851 ops/sec ±0.42% (91 runs sampled)
+  chalk x 9,944 ops/sec ±2.53% (81 runs sampled)))
+
+# Chained colors
+  ansi-colors x 20,791 ops/sec ±0.60% (88 runs sampled)
+  chalk x 2,111 ops/sec ±2.34% (83 runs sampled)
+
+# Nested colors
+  ansi-colors x 59,304 ops/sec ±0.98% (92 runs sampled)
+  chalk x 4,590 ops/sec ±2.08% (82 runs sampled)
+```
+
+### Windows
+
+> Windows 10, Intel Core i7-7700k CPU @ 4.2 GHz, 32 GB
+
+**Load time**
+
+Time it takes to load the first time `require()` is called:
+
+* ansi-colors - `1.494ms`
+* chalk - `11.523ms`
+
+**Benchmarks**
+
+```
+# All Colors
+  ansi-colors x 193,088 ops/sec ±0.51% (95 runs sampled))
+  chalk x 9,612 ops/sec ±3.31% (77 runs sampled)))
+
+# Chained colors
+  ansi-colors x 26,093 ops/sec ±1.13% (94 runs sampled)
+  chalk x 2,267 ops/sec ±2.88% (80 runs sampled))
+
+# Nested colors
+  ansi-colors x 67,747 ops/sec ±0.49% (93 runs sampled)
+  chalk x 4,446 ops/sec ±3.01% (82 runs sampled))
+```
+
+## About
+
+<details>
+<summary><strong>Contributing</strong></summary>
+
+Pull requests and stars are always welcome. For bugs and feature requests, [please create an issue](../../issues/new).
+
+</details>
+
+<details>
+<summary><strong>Running Tests</strong></summary>
+
+Running and reviewing unit tests is a great way to get familiarized with a library and its API. You can install dependencies and run tests with the following command:
+
+```sh
+$ npm install && npm test
+```
+
+</details>
+
+<details>
+<summary><strong>Building docs</strong></summary>
+
+_(This project's readme.md is generated by [verb](https://github.com/verbose/verb-generate-readme), please don't edit the readme directly. Any changes to the readme must be made in the [.verb.md](.verb.md) readme template.)_
+
+To generate the readme, run the following command:
+
+```sh
+$ npm install -g verbose/verb#dev verb-generate-readme && verb
+```
+
+</details>
+
+### Related projects
+
+You might also be interested in these projects:
+
+* [ansi-wrap](https://www.npmjs.com/package/ansi-wrap): Create ansi colors by passing the open and close codes. | [homepage](https://github.com/jonschlinkert/ansi-wrap "Create ansi colors by passing the open and close codes.")
+* [strip-color](https://www.npmjs.com/package/strip-color): Strip ANSI color codes from a string. No dependencies. | [homepage](https://github.com/jonschlinkert/strip-color "Strip ANSI color codes from a string. No dependencies.")
+
+### Contributors
+
+| **Commits** | **Contributor** |  
+| --- | --- |  
+| 38 | [jonschlinkert](https://github.com/jonschlinkert) |  
+| 38 | [doowb](https://github.com/doowb) |  
+| 6  | [lukeed](https://github.com/lukeed) |  
+| 2  | [Silic0nS0ldier](https://github.com/Silic0nS0ldier) |  
+| 1  | [dwieeb](https://github.com/dwieeb) |  
+| 1  | [jorgebucaran](https://github.com/jorgebucaran) |  
+| 1  | [madhavarshney](https://github.com/madhavarshney) |  
+| 1  | [Weishi93](https://github.com/Weishi93) |  
+| 1  | [chapterjason](https://github.com/chapterjason) |  
+
+### Author
+
+**Brian Woodward**
+
+* [GitHub Profile](https://github.com/doowb)
+* [Twitter Profile](https://twitter.com/doowb)
+* [LinkedIn Profile](https://linkedin.com/in/woodwardbrian)
+
+### License
+
+Copyright © 2018, [Brian Woodward](https://github.com/doowb).
+Released under the [MIT License](LICENSE).
+
+***
+
+_This file was generated by [verb-generate-readme](https://github.com/verbose/verb-generate-readme), v0.8.0, on December 03, 2018._

--- a/node_modules/argparse/README.md
+++ b/node_modules/argparse/README.md
@@ -1,0 +1,257 @@
+argparse
+========
+
+[![Build Status](https://secure.travis-ci.org/nodeca/argparse.svg?branch=master)](http://travis-ci.org/nodeca/argparse)
+[![NPM version](https://img.shields.io/npm/v/argparse.svg)](https://www.npmjs.org/package/argparse)
+
+CLI arguments parser for node.js. Javascript port of python's
+[argparse](http://docs.python.org/dev/library/argparse.html) module
+(original version 3.2). That's a full port, except some very rare options,
+recorded in issue tracker.
+
+**NB. Difference with original.**
+
+- Method names changed to camelCase. See [generated docs](http://nodeca.github.com/argparse/).
+- Use `defaultValue` instead of `default`.
+- Use `argparse.Const.REMAINDER` instead of `argparse.REMAINDER`, and
+  similarly for constant values `OPTIONAL`, `ZERO_OR_MORE`, and `ONE_OR_MORE`
+  (aliases for `nargs` values `'?'`, `'*'`, `'+'`, respectively), and
+  `SUPPRESS`.
+
+
+Example
+=======
+
+test.js file:
+
+```javascript
+#!/usr/bin/env node
+'use strict';
+
+var ArgumentParser = require('../lib/argparse').ArgumentParser;
+var parser = new ArgumentParser({
+  version: '0.0.1',
+  addHelp:true,
+  description: 'Argparse example'
+});
+parser.addArgument(
+  [ '-f', '--foo' ],
+  {
+    help: 'foo bar'
+  }
+);
+parser.addArgument(
+  [ '-b', '--bar' ],
+  {
+    help: 'bar foo'
+  }
+);
+parser.addArgument(
+  '--baz',
+  {
+    help: 'baz bar'
+  }
+);
+var args = parser.parseArgs();
+console.dir(args);
+```
+
+Display help:
+
+```
+$ ./test.js -h
+usage: example.js [-h] [-v] [-f FOO] [-b BAR] [--baz BAZ]
+
+Argparse example
+
+Optional arguments:
+  -h, --help         Show this help message and exit.
+  -v, --version      Show program's version number and exit.
+  -f FOO, --foo FOO  foo bar
+  -b BAR, --bar BAR  bar foo
+  --baz BAZ          baz bar
+```
+
+Parse arguments:
+
+```
+$ ./test.js -f=3 --bar=4 --baz 5
+{ foo: '3', bar: '4', baz: '5' }
+```
+
+More [examples](https://github.com/nodeca/argparse/tree/master/examples).
+
+
+ArgumentParser objects
+======================
+
+```
+new ArgumentParser({parameters hash});
+```
+
+Creates a new ArgumentParser object.
+
+**Supported params:**
+
+- ```description``` - Text to display before the argument help.
+- ```epilog``` - Text to display after the argument help.
+- ```addHelp``` - Add a -h/–help option to the parser. (default: true)
+- ```argumentDefault``` - Set the global default value for arguments. (default: null)
+- ```parents``` - A list of ArgumentParser objects whose arguments should also be included.
+- ```prefixChars``` - The set of characters that prefix optional arguments. (default: ‘-‘)
+- ```formatterClass``` - A class for customizing the help output.
+- ```prog``` - The name of the program (default: `path.basename(process.argv[1])`)
+- ```usage``` - The string describing the program usage (default: generated)
+- ```conflictHandler``` - Usually unnecessary, defines strategy for resolving conflicting optionals.
+
+**Not supported yet**
+
+- ```fromfilePrefixChars``` - The set of characters that prefix files from which additional arguments should be read.
+
+
+Details in [original ArgumentParser guide](http://docs.python.org/dev/library/argparse.html#argumentparser-objects)
+
+
+addArgument() method
+====================
+
+```
+ArgumentParser.addArgument(name or flag or [name] or [flags...], {options})
+```
+
+Defines how a single command-line argument should be parsed.
+
+- ```name or flag or [name] or [flags...]``` - Either a positional name
+  (e.g., `'foo'`), a single option (e.g., `'-f'` or `'--foo'`), an array
+  of a single positional name (e.g., `['foo']`), or an array of options
+  (e.g., `['-f', '--foo']`).
+
+Options:
+
+- ```action``` - The basic type of action to be taken when this argument is encountered at the command line.
+- ```nargs```- The number of command-line arguments that should be consumed.
+- ```constant``` - A constant value required by some action and nargs selections.
+- ```defaultValue``` - The value produced if the argument is absent from the command line.
+- ```type``` - The type to which the command-line argument should be converted.
+- ```choices``` - A container of the allowable values for the argument.
+- ```required``` - Whether or not the command-line option may be omitted (optionals only).
+- ```help``` - A brief description of what the argument does.
+- ```metavar``` - A name for the argument in usage messages.
+- ```dest``` - The name of the attribute to be added to the object returned by parseArgs().
+
+Details in [original add_argument guide](http://docs.python.org/dev/library/argparse.html#the-add-argument-method)
+
+
+Action (some details)
+================
+
+ArgumentParser objects associate command-line arguments with actions.
+These actions can do just about anything with the command-line arguments associated
+with them, though most actions simply add an attribute to the object returned by
+parseArgs(). The action keyword argument specifies how the command-line arguments
+should be handled. The supported actions are:
+
+- ```store``` - Just stores the argument’s value. This is the default action.
+- ```storeConst``` - Stores value, specified by the const keyword argument.
+  (Note that the const keyword argument defaults to the rather unhelpful None.)
+  The 'storeConst' action is most commonly used with optional arguments, that
+  specify some sort of flag.
+- ```storeTrue``` and ```storeFalse``` - Stores values True and False
+  respectively. These are special cases of 'storeConst'.
+- ```append``` - Stores a list, and appends each argument value to the list.
+  This is useful to allow an option to be specified multiple times.
+- ```appendConst``` - Stores a list, and appends value, specified by the
+  const keyword argument to the list. (Note, that the const keyword argument defaults
+  is None.) The 'appendConst' action is typically used when multiple arguments need
+  to store constants to the same list.
+- ```count``` - Counts the number of times a keyword argument occurs. For example,
+  used for increasing verbosity levels.
+- ```help``` - Prints a complete help message for all the options in the current
+  parser and then exits. By default a help action is automatically added to the parser.
+  See ArgumentParser for details of how the output is created.
+- ```version``` - Prints version information and exit. Expects a `version=`
+  keyword argument in the addArgument() call.
+
+Details in [original action guide](http://docs.python.org/dev/library/argparse.html#action)
+
+
+Sub-commands
+============
+
+ArgumentParser.addSubparsers()
+
+Many programs split their functionality into a number of sub-commands, for
+example, the svn program can invoke sub-commands like `svn checkout`, `svn update`,
+and `svn commit`. Splitting up functionality this way can be a particularly good
+idea when a program performs several different functions which require different
+kinds of command-line arguments. `ArgumentParser` supports creation of such
+sub-commands with `addSubparsers()` method. The `addSubparsers()` method is
+normally called with no arguments and returns an special action object.
+This object has a single method `addParser()`, which takes a command name and
+any `ArgumentParser` constructor arguments, and returns an `ArgumentParser` object
+that can be modified as usual.
+
+Example:
+
+sub_commands.js
+```javascript
+#!/usr/bin/env node
+'use strict';
+
+var ArgumentParser = require('../lib/argparse').ArgumentParser;
+var parser = new ArgumentParser({
+  version: '0.0.1',
+  addHelp:true,
+  description: 'Argparse examples: sub-commands',
+});
+
+var subparsers = parser.addSubparsers({
+  title:'subcommands',
+  dest:"subcommand_name"
+});
+
+var bar = subparsers.addParser('c1', {addHelp:true});
+bar.addArgument(
+  [ '-f', '--foo' ],
+  {
+    action: 'store',
+    help: 'foo3 bar3'
+  }
+);
+var bar = subparsers.addParser(
+  'c2',
+  {aliases:['co'], addHelp:true}
+);
+bar.addArgument(
+  [ '-b', '--bar' ],
+  {
+    action: 'store',
+    type: 'int',
+    help: 'foo3 bar3'
+  }
+);
+
+var args = parser.parseArgs();
+console.dir(args);
+
+```
+
+Details in [original sub-commands guide](http://docs.python.org/dev/library/argparse.html#sub-commands)
+
+
+Contributors
+============
+
+- [Eugene Shkuropat](https://github.com/shkuropat)
+- [Paul Jacobson](https://github.com/hpaulj)
+
+[others](https://github.com/nodeca/argparse/graphs/contributors)
+
+License
+=======
+
+Copyright (c) 2012 [Vitaly Puzrin](https://github.com/puzrin).
+Released under the MIT license. See
+[LICENSE](https://github.com/nodeca/argparse/blob/master/LICENSE) for details.
+
+

--- a/node_modules/balanced-match/README.md
+++ b/node_modules/balanced-match/README.md
@@ -1,0 +1,91 @@
+# balanced-match
+
+Match balanced string pairs, like `{` and `}` or `<b>` and `</b>`. Supports regular expressions as well!
+
+[![build status](https://secure.travis-ci.org/juliangruber/balanced-match.svg)](http://travis-ci.org/juliangruber/balanced-match)
+[![downloads](https://img.shields.io/npm/dm/balanced-match.svg)](https://www.npmjs.org/package/balanced-match)
+
+[![testling badge](https://ci.testling.com/juliangruber/balanced-match.png)](https://ci.testling.com/juliangruber/balanced-match)
+
+## Example
+
+Get the first matching pair of braces:
+
+```js
+var balanced = require('balanced-match');
+
+console.log(balanced('{', '}', 'pre{in{nested}}post'));
+console.log(balanced('{', '}', 'pre{first}between{second}post'));
+console.log(balanced(/\s+\{\s+/, /\s+\}\s+/, 'pre  {   in{nest}   }  post'));
+```
+
+The matches are:
+
+```bash
+$ node example.js
+{ start: 3, end: 14, pre: 'pre', body: 'in{nested}', post: 'post' }
+{ start: 3,
+  end: 9,
+  pre: 'pre',
+  body: 'first',
+  post: 'between{second}post' }
+{ start: 3, end: 17, pre: 'pre', body: 'in{nest}', post: 'post' }
+```
+
+## API
+
+### var m = balanced(a, b, str)
+
+For the first non-nested matching pair of `a` and `b` in `str`, return an
+object with those keys:
+
+* **start** the index of the first match of `a`
+* **end** the index of the matching `b`
+* **pre** the preamble, `a` and `b` not included
+* **body** the match, `a` and `b` not included
+* **post** the postscript, `a` and `b` not included
+
+If there's no match, `undefined` will be returned.
+
+If the `str` contains more `a` than `b` / there are unmatched pairs, the first match that was closed will be used. For example, `{{a}` will match `['{', 'a', '']` and `{a}}` will match `['', 'a', '}']`.
+
+### var r = balanced.range(a, b, str)
+
+For the first non-nested matching pair of `a` and `b` in `str`, return an
+array with indexes: `[ <a index>, <b index> ]`.
+
+If there's no match, `undefined` will be returned.
+
+If the `str` contains more `a` than `b` / there are unmatched pairs, the first match that was closed will be used. For example, `{{a}` will match `[ 1, 3 ]` and `{a}}` will match `[0, 2]`.
+
+## Installation
+
+With [npm](https://npmjs.org) do:
+
+```bash
+npm install balanced-match
+```
+
+## License
+
+(MIT)
+
+Copyright (c) 2013 Julian Gruber &lt;julian@juliangruber.com&gt;
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/node_modules/brace-expansion/README.md
+++ b/node_modules/brace-expansion/README.md
@@ -1,0 +1,129 @@
+# brace-expansion
+
+[Brace expansion](https://www.gnu.org/software/bash/manual/html_node/Brace-Expansion.html), 
+as known from sh/bash, in JavaScript.
+
+[![build status](https://secure.travis-ci.org/juliangruber/brace-expansion.svg)](http://travis-ci.org/juliangruber/brace-expansion)
+[![downloads](https://img.shields.io/npm/dm/brace-expansion.svg)](https://www.npmjs.org/package/brace-expansion)
+[![Greenkeeper badge](https://badges.greenkeeper.io/juliangruber/brace-expansion.svg)](https://greenkeeper.io/)
+
+[![testling badge](https://ci.testling.com/juliangruber/brace-expansion.png)](https://ci.testling.com/juliangruber/brace-expansion)
+
+## Example
+
+```js
+var expand = require('brace-expansion');
+
+expand('file-{a,b,c}.jpg')
+// => ['file-a.jpg', 'file-b.jpg', 'file-c.jpg']
+
+expand('-v{,,}')
+// => ['-v', '-v', '-v']
+
+expand('file{0..2}.jpg')
+// => ['file0.jpg', 'file1.jpg', 'file2.jpg']
+
+expand('file-{a..c}.jpg')
+// => ['file-a.jpg', 'file-b.jpg', 'file-c.jpg']
+
+expand('file{2..0}.jpg')
+// => ['file2.jpg', 'file1.jpg', 'file0.jpg']
+
+expand('file{0..4..2}.jpg')
+// => ['file0.jpg', 'file2.jpg', 'file4.jpg']
+
+expand('file-{a..e..2}.jpg')
+// => ['file-a.jpg', 'file-c.jpg', 'file-e.jpg']
+
+expand('file{00..10..5}.jpg')
+// => ['file00.jpg', 'file05.jpg', 'file10.jpg']
+
+expand('{{A..C},{a..c}}')
+// => ['A', 'B', 'C', 'a', 'b', 'c']
+
+expand('ppp{,config,oe{,conf}}')
+// => ['ppp', 'pppconfig', 'pppoe', 'pppoeconf']
+```
+
+## API
+
+```js
+var expand = require('brace-expansion');
+```
+
+### var expanded = expand(str)
+
+Return an array of all possible and valid expansions of `str`. If none are
+found, `[str]` is returned.
+
+Valid expansions are:
+
+```js
+/^(.*,)+(.+)?$/
+// {a,b,...}
+```
+
+A comma separated list of options, like `{a,b}` or `{a,{b,c}}` or `{,a,}`.
+
+```js
+/^-?\d+\.\.-?\d+(\.\.-?\d+)?$/
+// {x..y[..incr]}
+```
+
+A numeric sequence from `x` to `y` inclusive, with optional increment.
+If `x` or `y` start with a leading `0`, all the numbers will be padded
+to have equal length. Negative numbers and backwards iteration work too.
+
+```js
+/^-?\d+\.\.-?\d+(\.\.-?\d+)?$/
+// {x..y[..incr]}
+```
+
+An alphabetic sequence from `x` to `y` inclusive, with optional increment.
+`x` and `y` must be exactly one character, and if given, `incr` must be a
+number.
+
+For compatibility reasons, the string `${` is not eligible for brace expansion.
+
+## Installation
+
+With [npm](https://npmjs.org) do:
+
+```bash
+npm install brace-expansion
+```
+
+## Contributors
+
+- [Julian Gruber](https://github.com/juliangruber)
+- [Isaac Z. Schlueter](https://github.com/isaacs)
+
+## Sponsors
+
+This module is proudly supported by my [Sponsors](https://github.com/juliangruber/sponsors)!
+
+Do you want to support modules like this to improve their quality, stability and weigh in on new features? Then please consider donating to my [Patreon](https://www.patreon.com/juliangruber). Not sure how much of my modules you're using? Try [feross/thanks](https://github.com/feross/thanks)!
+
+## License
+
+(MIT)
+
+Copyright (c) 2013 Julian Gruber &lt;julian@juliangruber.com&gt;
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/node_modules/browser-stdout/README.md
+++ b/node_modules/browser-stdout/README.md
@@ -1,0 +1,40 @@
+### wat?
+
+`process.stdout` in your browser.
+
+### wai?
+
+iono. cuz hakz.
+
+### hau?
+
+```js
+var BrowserStdout = require('browser-stdout')
+
+myStream.pipe(BrowserStdout())
+```
+
+### monkey
+
+You can monkey-patch `process.stdout` for your dependency graph like this:
+
+```
+process.stdout = require('browser-stdout')()
+var coolTool = require('module-that-uses-stdout-somewhere-in-its-depths')
+```
+
+### opts
+
+opts are passed directly to `stream.Writable`.
+additionally, a label arg can be used to label console output.
+
+```js
+BrowserStdout({
+  objectMode: true,
+  label: 'dataz',
+})
+```
+
+### ur doin it rong
+
+i accept pr's.

--- a/node_modules/cliui/README.md
+++ b/node_modules/cliui/README.md
@@ -1,0 +1,115 @@
+# cliui
+
+[![Build Status](https://travis-ci.org/yargs/cliui.svg)](https://travis-ci.org/yargs/cliui)
+[![Coverage Status](https://coveralls.io/repos/yargs/cliui/badge.svg?branch=)](https://coveralls.io/r/yargs/cliui?branch=)
+[![NPM version](https://img.shields.io/npm/v/cliui.svg)](https://www.npmjs.com/package/cliui)
+[![Standard Version](https://img.shields.io/badge/release-standard%20version-brightgreen.svg)](https://github.com/conventional-changelog/standard-version)
+
+easily create complex multi-column command-line-interfaces.
+
+## Example
+
+```js
+var ui = require('cliui')()
+
+ui.div('Usage: $0 [command] [options]')
+
+ui.div({
+  text: 'Options:',
+  padding: [2, 0, 2, 0]
+})
+
+ui.div(
+  {
+    text: "-f, --file",
+    width: 20,
+    padding: [0, 4, 0, 4]
+  },
+  {
+    text: "the file to load." +
+      chalk.green("(if this description is long it wraps).")
+    ,
+    width: 20
+  },
+  {
+    text: chalk.red("[required]"),
+    align: 'right'
+  }
+)
+
+console.log(ui.toString())
+```
+
+<img width="500" src="screenshot.png">
+
+## Layout DSL
+
+cliui exposes a simple layout DSL:
+
+If you create a single `ui.row`, passing a string rather than an
+object:
+
+* `\n`: characters will be interpreted as new rows.
+* `\t`: characters will be interpreted as new columns.
+* `\s`: characters will be interpreted as padding.
+
+**as an example...**
+
+```js
+var ui = require('./')({
+  width: 60
+})
+
+ui.div(
+  'Usage: node ./bin/foo.js\n' +
+  '  <regex>\t  provide a regex\n' +
+  '  <glob>\t  provide a glob\t [required]'
+)
+
+console.log(ui.toString())
+```
+
+**will output:**
+
+```shell
+Usage: node ./bin/foo.js
+  <regex>  provide a regex
+  <glob>   provide a glob          [required]
+```
+
+## Methods
+
+```js
+cliui = require('cliui')
+```
+
+### cliui({width: integer})
+
+Specify the maximum width of the UI being generated.
+If no width is provided, cliui will try to get the current window's width and use it, and if that doesn't work, width will be set to `80`.
+
+### cliui({wrap: boolean})
+
+Enable or disable the wrapping of text in a column.
+
+### cliui.div(column, column, column)
+
+Create a row with any number of columns, a column
+can either be a string, or an object with the following
+options:
+
+* **text:** some text to place in the column.
+* **width:** the width of a column.
+* **align:** alignment, `right` or `center`.
+* **padding:** `[top, right, bottom, left]`.
+* **border:** should a border be placed around the div?
+
+### cliui.span(column, column, column)
+
+Similar to `div`, except the next row will be appended without
+a new line being created.
+
+### cliui.resetOutput()
+
+Resets the UI elements of the current cliui instance, maintaining the values
+set for `width` and `wrap`.

--- a/node_modules/color-convert/README.md
+++ b/node_modules/color-convert/README.md
@@ -1,0 +1,68 @@
+# color-convert
+
+[![Build Status](https://travis-ci.org/Qix-/color-convert.svg?branch=master)](https://travis-ci.org/Qix-/color-convert)
+
+Color-convert is a color conversion library for JavaScript and node.
+It converts all ways between `rgb`, `hsl`, `hsv`, `hwb`, `cmyk`, `ansi`, `ansi16`, `hex` strings, and CSS `keyword`s (will round to closest):
+
+```js
+var convert = require('color-convert');
+
+convert.rgb.hsl(140, 200, 100);             // [96, 48, 59]
+convert.keyword.rgb('blue');                // [0, 0, 255]
+
+var rgbChannels = convert.rgb.channels;     // 3
+var cmykChannels = convert.cmyk.channels;   // 4
+var ansiChannels = convert.ansi16.channels; // 1
+```
+
+# Install
+
+```console
+$ npm install color-convert
+```
+
+# API
+
+Simply get the property of the _from_ and _to_ conversion that you're looking for.
+
+All functions have a rounded and unrounded variant. By default, return values are rounded. To get the unrounded (raw) results, simply tack on `.raw` to the function.
+
+All 'from' functions have a hidden property called `.channels` that indicates the number of channels the function expects (not including alpha).
+
+```js
+var convert = require('color-convert');
+
+// Hex to LAB
+convert.hex.lab('DEADBF');         // [ 76, 21, -2 ]
+convert.hex.lab.raw('DEADBF');     // [ 75.56213190997677, 20.653827952644754, -2.290532499330533 ]
+
+// RGB to CMYK
+convert.rgb.cmyk(167, 255, 4);     // [ 35, 0, 98, 0 ]
+convert.rgb.cmyk.raw(167, 255, 4); // [ 34.509803921568626, 0, 98.43137254901961, 0 ]
+```
+
+### Arrays
+All functions that accept multiple arguments also support passing an array.
+
+Note that this does **not** apply to functions that convert from a color that only requires one value (e.g. `keyword`, `ansi256`, `hex`, etc.)
+
+```js
+var convert = require('color-convert');
+
+convert.rgb.hex(123, 45, 67);      // '7B2D43'
+convert.rgb.hex([123, 45, 67]);    // '7B2D43'
+```
+
+## Routing
+
+Conversions that don't have an _explicitly_ defined conversion (in [conversions.js](conversions.js)), but can be converted by means of sub-conversions (e.g. XYZ -> **RGB** -> CMYK), are automatically routed together. This allows just about any color model supported by `color-convert` to be converted to any other model, so long as a sub-conversion path exists. This is also true for conversions requiring more than one step in between (e.g. LCH -> **LAB** -> **XYZ** -> **RGB** -> Hex).
+
+Keep in mind that extensive conversions _may_ result in a loss of precision, and exist only to be complete. For a list of "direct" (single-step) conversions, see [conversions.js](conversions.js).
+
+# Contribute
+
+If there is a new model you would like to support, or want to add a direct conversion between two existing models, please send us a pull request.
+
+# License
+Copyright &copy; 2011-2016, Heather Arthur and Josh Junon. Licensed under the [MIT License](LICENSE).

--- a/node_modules/color-name/README.md
+++ b/node_modules/color-name/README.md
@@ -1,0 +1,11 @@
+A JSON with color names and its values. Based on http://dev.w3.org/csswg/css-color/#named-colors.
+
+[![NPM](https://nodei.co/npm/color-name.png?mini=true)](https://nodei.co/npm/color-name/)
+
+
+```js
+var colors = require('color-name');
+colors.red //[255,0,0]
+```
+
+<a href="LICENSE"><img src="https://upload.wikimedia.org/wikipedia/commons/0/0c/MIT_logo.svg" width="120"/></a>

--- a/node_modules/cross-spawn/README.md
+++ b/node_modules/cross-spawn/README.md
@@ -1,0 +1,94 @@
+# cross-spawn
+
+[![NPM version][npm-image]][npm-url] [![Downloads][downloads-image]][npm-url] [![Build Status][travis-image]][travis-url] [![Build status][appveyor-image]][appveyor-url] [![Coverage Status][codecov-image]][codecov-url] [![Dependency status][david-dm-image]][david-dm-url] [![Dev Dependency status][david-dm-dev-image]][david-dm-dev-url] [![Greenkeeper badge][greenkeeper-image]][greenkeeper-url]
+
+[npm-url]:https://npmjs.org/package/cross-spawn
+[downloads-image]:http://img.shields.io/npm/dm/cross-spawn.svg
+[npm-image]:http://img.shields.io/npm/v/cross-spawn.svg
+[travis-url]:https://travis-ci.org/moxystudio/node-cross-spawn
+[travis-image]:http://img.shields.io/travis/moxystudio/node-cross-spawn/master.svg
+[appveyor-url]:https://ci.appveyor.com/project/satazor/node-cross-spawn
+[appveyor-image]:https://img.shields.io/appveyor/ci/satazor/node-cross-spawn/master.svg
+[codecov-url]:https://codecov.io/gh/moxystudio/node-cross-spawn
+[codecov-image]:https://img.shields.io/codecov/c/github/moxystudio/node-cross-spawn/master.svg
+[david-dm-url]:https://david-dm.org/moxystudio/node-cross-spawn
+[david-dm-image]:https://img.shields.io/david/moxystudio/node-cross-spawn.svg
+[david-dm-dev-url]:https://david-dm.org/moxystudio/node-cross-spawn?type=dev
+[david-dm-dev-image]:https://img.shields.io/david/dev/moxystudio/node-cross-spawn.svg
+[greenkeeper-image]:https://badges.greenkeeper.io/moxystudio/node-cross-spawn.svg
+[greenkeeper-url]:https://greenkeeper.io/
+
+A cross platform solution to node's spawn and spawnSync.
+
+
+## Installation
+
+`$ npm install cross-spawn`
+
+
+## Why
+
+Node has issues when using spawn on Windows:
+
+- It ignores [PATHEXT](https://github.com/joyent/node/issues/2318)
+- It does not support [shebangs](https://en.wikipedia.org/wiki/Shebang_(Unix))
+- Has problems running commands with [spaces](https://github.com/nodejs/node/issues/7367)
+- Has problems running commands with posix relative paths (e.g.: `./my-folder/my-executable`)
+- Has an [issue](https://github.com/moxystudio/node-cross-spawn/issues/82) with command shims (files in `node_modules/.bin/`), where arguments with quotes and parenthesis would result in [invalid syntax error](https://github.com/moxystudio/node-cross-spawn/blob/e77b8f22a416db46b6196767bcd35601d7e11d54/test/index.test.js#L149)
+- No `options.shell` support on node `<v4.8`
+
+All these issues are handled correctly by `cross-spawn`.
+There are some known modules, such as [win-spawn](https://github.com/ForbesLindesay/win-spawn), that try to solve this but they are either broken or provide faulty escaping of shell arguments.
+
+
+## Usage
+
+Exactly the same way as node's [`spawn`](https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options) or [`spawnSync`](https://nodejs.org/api/child_process.html#child_process_child_process_spawnsync_command_args_options), so it's a drop in replacement.
+
+
+```js
+const spawn = require('cross-spawn');
+
+// Spawn NPM asynchronously
+const child = spawn('npm', ['list', '-g', '-depth', '0'], { stdio: 'inherit' });
+
+// Spawn NPM synchronously
+const result = spawn.sync('npm', ['list', '-g', '-depth', '0'], { stdio: 'inherit' });
+```
+
+
+## Caveats
+
+### Using `options.shell` as an alternative to `cross-spawn`
+
+Starting from node `v4.8`, `spawn` has a `shell` option that allows you run commands from within a shell. This new option solves
+the [PATHEXT](https://github.com/joyent/node/issues/2318) issue but:
+
+- It's not supported in node `<v4.8`
+- You must manually escape the command and arguments which is very error prone, specially when passing user input
+- There are a lot of other unresolved issues from the [Why](#why) section that you must take into account
+
+If you are using the `shell` option to spawn a command in a cross platform way, consider using `cross-spawn` instead. You have been warned.
+
+### `options.shell` support
+
+While `cross-spawn` adds support for `options.shell` in node `<v4.8`, all of its enhancements are disabled.
+
+This mimics the Node.js behavior. More specifically, the command and its arguments will not be automatically escaped nor shebang support will be offered. This is by design because if you are using `options.shell` you are probably targeting a specific platform anyway and you don't want things to get into your way.
+
+### Shebangs support
+
+While `cross-spawn` handles shebangs on Windows, its support is limited. More specifically, it just supports `#!/usr/bin/env <program>` where `<program>` must not contain any arguments.   
+If you would like to have the shebang support improved, feel free to contribute via a pull-request.
+
+Remember to always test your code on Windows!
+
+
+## Tests
+
+`$ npm test`   
+`$ npm test -- --watch` during development
+
+## License
+
+Released under the [MIT License](http://www.opensource.org/licenses/mit-license.php).

--- a/node_modules/debug/README.md
+++ b/node_modules/debug/README.md
@@ -1,0 +1,437 @@
+# debug
+[![Build Status](https://travis-ci.org/visionmedia/debug.svg?branch=master)](https://travis-ci.org/visionmedia/debug)  [![Coverage Status](https://coveralls.io/repos/github/visionmedia/debug/badge.svg?branch=master)](https://coveralls.io/github/visionmedia/debug?branch=master)  [![Slack](https://visionmedia-community-slackin.now.sh/badge.svg)](https://visionmedia-community-slackin.now.sh/) [![OpenCollective](https://opencollective.com/debug/backers/badge.svg)](#backers)
+[![OpenCollective](https://opencollective.com/debug/sponsors/badge.svg)](#sponsors)
+
+<img width="647" src="https://user-images.githubusercontent.com/71256/29091486-fa38524c-7c37-11e7-895f-e7ec8e1039b6.png">
+
+A tiny JavaScript debugging utility modelled after Node.js core's debugging
+technique. Works in Node.js and web browsers.
+
+## Installation
+
+```bash
+$ npm install debug
+```
+
+## Usage
+
+`debug` exposes a function; simply pass this function the name of your module, and it will return a decorated version of `console.error` for you to pass debug statements to. This will allow you to toggle the debug output for different parts of your module as well as the module as a whole.
+
+Example [_app.js_](./examples/node/app.js):
+
+```js
+var debug = require('debug')('http')
+  , http = require('http')
+  , name = 'My App';
+
+// fake app
+
+debug('booting %o', name);
+
+http.createServer(function(req, res){
+  debug(req.method + ' ' + req.url);
+  res.end('hello\n');
+}).listen(3000, function(){
+  debug('listening');
+});
+
+// fake worker of some kind
+
+require('./worker');
+```
+
+Example [_worker.js_](./examples/node/worker.js):
+
+```js
+var a = require('debug')('worker:a')
+  , b = require('debug')('worker:b');
+
+function work() {
+  a('doing lots of uninteresting work');
+  setTimeout(work, Math.random() * 1000);
+}
+
+work();
+
+function workb() {
+  b('doing some work');
+  setTimeout(workb, Math.random() * 2000);
+}
+
+workb();
+```
+
+The `DEBUG` environment variable is then used to enable these based on space or
+comma-delimited names.
+
+Here are some examples:
+
+<img width="647" alt="screen shot 2017-08-08 at 12 53 04 pm" src="https://user-images.githubusercontent.com/71256/29091703-a6302cdc-7c38-11e7-8304-7c0b3bc600cd.png">
+<img width="647" alt="screen shot 2017-08-08 at 12 53 38 pm" src="https://user-images.githubusercontent.com/71256/29091700-a62a6888-7c38-11e7-800b-db911291ca2b.png">
+<img width="647" alt="screen shot 2017-08-08 at 12 53 25 pm" src="https://user-images.githubusercontent.com/71256/29091701-a62ea114-7c38-11e7-826a-2692bedca740.png">
+
+#### Windows command prompt notes
+
+##### CMD
+
+On Windows the environment variable is set using the `set` command.
+
+```cmd
+set DEBUG=*,-not_this
+```
+
+Example:
+
+```cmd
+set DEBUG=* & node app.js
+```
+
+##### PowerShell (VS Code default)
+
+PowerShell uses different syntax to set environment variables.
+
+```cmd
+$env:DEBUG = "*,-not_this"
+```
+
+Example:
+
+```cmd
+$env:DEBUG='app';node app.js
+```
+
+Then, run the program to be debugged as usual.
+
+npm script example:
+```js
+  "windowsDebug": "@powershell -Command $env:DEBUG='*';node app.js",
+```
+
+## Namespace Colors
+
+Every debug instance has a color generated for it based on its namespace name.
+This helps when visually parsing the debug output to identify which debug instance
+a debug line belongs to.
+
+#### Node.js
+
+In Node.js, colors are enabled when stderr is a TTY. You also _should_ install
+the [`supports-color`](https://npmjs.org/supports-color) module alongside debug,
+otherwise debug will only use a small handful of basic colors.
+
+<img width="521" src="https://user-images.githubusercontent.com/71256/29092181-47f6a9e6-7c3a-11e7-9a14-1928d8a711cd.png">
+
+#### Web Browser
+
+Colors are also enabled on "Web Inspectors" that understand the `%c` formatting
+option. These are WebKit web inspectors, Firefox ([since version
+31](https://hacks.mozilla.org/2014/05/editable-box-model-multiple-selection-sublime-text-keys-much-more-firefox-developer-tools-episode-31/))
+and the Firebug plugin for Firefox (any version).
+
+<img width="524" src="https://user-images.githubusercontent.com/71256/29092033-b65f9f2e-7c39-11e7-8e32-f6f0d8e865c1.png">
+
+
+## Millisecond diff
+
+When actively developing an application it can be useful to see when the time spent between one `debug()` call and the next. Suppose for example you invoke `debug()` before requesting a resource, and after as well, the "+NNNms" will show you how much time was spent between calls.
+
+<img width="647" src="https://user-images.githubusercontent.com/71256/29091486-fa38524c-7c37-11e7-895f-e7ec8e1039b6.png">
+
+When stdout is not a TTY, `Date#toISOString()` is used, making it more useful for logging the debug information as shown below:
+
+<img width="647" src="https://user-images.githubusercontent.com/71256/29091956-6bd78372-7c39-11e7-8c55-c948396d6edd.png">
+
+
+## Conventions
+
+If you're using this in one or more of your libraries, you _should_ use the name of your library so that developers may toggle debugging as desired without guessing names. If you have more than one debuggers you _should_ prefix them with your library name and use ":" to separate features. For example "bodyParser" from Connect would then be "connect:bodyParser".  If you append a "*" to the end of your name, it will always be enabled regardless of the setting of the DEBUG environment variable.  You can then use it for normal output as well as debug output.
+
+## Wildcards
+
+The `*` character may be used as a wildcard. Suppose for example your library has
+debuggers named "connect:bodyParser", "connect:compress", "connect:session",
+instead of listing all three with
+`DEBUG=connect:bodyParser,connect:compress,connect:session`, you may simply do
+`DEBUG=connect:*`, or to run everything using this module simply use `DEBUG=*`.
+
+You can also exclude specific debuggers by prefixing them with a "-" character.
+For example, `DEBUG=*,-connect:*` would include all debuggers except those
+starting with "connect:".
+
+## Environment Variables
+
+When running through Node.js, you can set a few environment variables that will
+change the behavior of the debug logging:
+
+| Name      | Purpose                                         |
+|-----------|-------------------------------------------------|
+| `DEBUG`   | Enables/disables specific debugging namespaces. |
+| `DEBUG_HIDE_DATE` | Hide date from debug output (non-TTY).  |
+| `DEBUG_COLORS`| Whether or not to use colors in the debug output. |
+| `DEBUG_DEPTH` | Object inspection depth.                    |
+| `DEBUG_SHOW_HIDDEN` | Shows hidden properties on inspected objects. |
+
+
+__Note:__ The environment variables beginning with `DEBUG_` end up being
+converted into an Options object that gets used with `%o`/`%O` formatters.
+See the Node.js documentation for
+[`util.inspect()`](https://nodejs.org/api/util.html#util_util_inspect_object_options)
+for the complete list.
+
+## Formatters
+
+Debug uses [printf-style](https://wikipedia.org/wiki/Printf_format_string) formatting.
+Below are the officially supported formatters:
+
+| Formatter | Representation |
+|-----------|----------------|
+| `%O`      | Pretty-print an Object on multiple lines. |
+| `%o`      | Pretty-print an Object all on a single line. |
+| `%s`      | String. |
+| `%d`      | Number (both integer and float). |
+| `%j`      | JSON. Replaced with the string '[Circular]' if the argument contains circular references. |
+| `%%`      | Single percent sign ('%'). This does not consume an argument. |
+
+
+### Custom formatters
+
+You can add custom formatters by extending the `debug.formatters` object.
+For example, if you wanted to add support for rendering a Buffer as hex with
+`%h`, you could do something like:
+
+```js
+const createDebug = require('debug')
+createDebug.formatters.h = (v) => {
+  return v.toString('hex')
+}
+
+// …elsewhere
+const debug = createDebug('foo')
+debug('this is hex: %h', new Buffer('hello world'))
+//   foo this is hex: 68656c6c6f20776f726c6421 +0ms
+```
+
+
+## Browser Support
+
+You can build a browser-ready script using [browserify](https://github.com/substack/node-browserify),
+or just use the [browserify-as-a-service](https://wzrd.in/) [build](https://wzrd.in/standalone/debug@latest),
+if you don't want to build it yourself.
+
+Debug's enable state is currently persisted by `localStorage`.
+Consider the situation shown below where you have `worker:a` and `worker:b`,
+and wish to debug both. You can enable this using `localStorage.debug`:
+
+```js
+localStorage.debug = 'worker:*'
+```
+
+And then refresh the page.
+
+```js
+a = debug('worker:a');
+b = debug('worker:b');
+
+setInterval(function(){
+  a('doing some work');
+}, 1000);
+
+setInterval(function(){
+  b('doing some work');
+}, 1200);
+```
+
+
+## Output streams
+
+  By default `debug` will log to stderr, however this can be configured per-namespace by overriding the `log` method:
+
+Example [_stdout.js_](./examples/node/stdout.js):
+
+```js
+var debug = require('debug');
+var error = debug('app:error');
+
+// by default stderr is used
+error('goes to stderr!');
+
+var log = debug('app:log');
+// set this namespace to log via console.log
+log.log = console.log.bind(console); // don't forget to bind to console!
+log('goes to stdout');
+error('still goes to stderr!');
+
+// set all output to go via console.info
+// overrides all per-namespace log settings
+debug.log = console.info.bind(console);
+error('now goes to stdout via console.info');
+log('still goes to stdout, but via console.info now');
+```
+
+## Extend
+You can simply extend debugger 
+```js
+const log = require('debug')('auth');
+
+//creates new debug instance with extended namespace
+const logSign = log.extend('sign');
+const logLogin = log.extend('login');
+
+log('hello'); // auth hello
+logSign('hello'); //auth:sign hello
+logLogin('hello'); //auth:login hello
+```
+
+## Set dynamically
+
+You can also enable debug dynamically by calling the `enable()` method :
+
+```js
+let debug = require('debug');
+
+console.log(1, debug.enabled('test'));
+
+debug.enable('test');
+console.log(2, debug.enabled('test'));
+
+debug.disable();
+console.log(3, debug.enabled('test'));
+
+```
+
+print :   
+```
+1 false
+2 true
+3 false
+```
+
+Usage :  
+`enable(namespaces)`  
+`namespaces` can include modes separated by a colon and wildcards.
+   
+Note that calling `enable()` completely overrides previously set DEBUG variable : 
+
+```
+$ DEBUG=foo node -e 'var dbg = require("debug"); dbg.enable("bar"); console.log(dbg.enabled("foo"))'
+=> false
+```
+
+## Checking whether a debug target is enabled
+
+After you've created a debug instance, you can determine whether or not it is
+enabled by checking the `enabled` property:
+
+```javascript
+const debug = require('debug')('http');
+
+if (debug.enabled) {
+  // do stuff...
+}
+```
+
+You can also manually toggle this property to force the debug instance to be
+enabled or disabled.
+
+
+## Authors
+
+ - TJ Holowaychuk
+ - Nathan Rajlich
+ - Andrew Rhyne
+
+## Backers
+
+Support us with a monthly donation and help us continue our activities. [[Become a backer](https://opencollective.com/debug#backer)]
+
+<a href="https://opencollective.com/debug/backer/0/website" target="_blank"><img src="https://opencollective.com/debug/backer/0/avatar.svg"></a>
+<a href="https://opencollective.com/debug/backer/1/website" target="_blank"><img src="https://opencollective.com/debug/backer/1/avatar.svg"></a>
+<a href="https://opencollective.com/debug/backer/2/website" target="_blank"><img src="https://opencollective.com/debug/backer/2/avatar.svg"></a>
+<a href="https://opencollective.com/debug/backer/3/website" target="_blank"><img src="https://opencollective.com/debug/backer/3/avatar.svg"></a>
+<a href="https://opencollective.com/debug/backer/4/website" target="_blank"><img src="https://opencollective.com/debug/backer/4/avatar.svg"></a>
+<a href="https://opencollective.com/debug/backer/5/website" target="_blank"><img src="https://opencollective.com/debug/backer/5/avatar.svg"></a>
+<a href="https://opencollective.com/debug/backer/6/website" target="_blank"><img src="https://opencollective.com/debug/backer/6/avatar.svg"></a>
+<a href="https://opencollective.com/debug/backer/7/website" target="_blank"><img src="https://opencollective.com/debug/backer/7/avatar.svg"></a>
+<a href="https://opencollective.com/debug/backer/8/website" target="_blank"><img src="https://opencollective.com/debug/backer/8/avatar.svg"></a>
+<a href="https://opencollective.com/debug/backer/9/website" target="_blank"><img src="https://opencollective.com/debug/backer/9/avatar.svg"></a>
+<a href="https://opencollective.com/debug/backer/10/website" target="_blank"><img src="https://opencollective.com/debug/backer/10/avatar.svg"></a>
+<a href="https://opencollective.com/debug/backer/11/website" target="_blank"><img src="https://opencollective.com/debug/backer/11/avatar.svg"></a>
+<a href="https://opencollective.com/debug/backer/12/website" target="_blank"><img src="https://opencollective.com/debug/backer/12/avatar.svg"></a>
+<a href="https://opencollective.com/debug/backer/13/website" target="_blank"><img src="https://opencollective.com/debug/backer/13/avatar.svg"></a>
+<a href="https://opencollective.com/debug/backer/14/website" target="_blank"><img src="https://opencollective.com/debug/backer/14/avatar.svg"></a>
+<a href="https://opencollective.com/debug/backer/15/website" target="_blank"><img src="https://opencollective.com/debug/backer/15/avatar.svg"></a>
+<a href="https://opencollective.com/debug/backer/16/website" target="_blank"><img src="https://opencollective.com/debug/backer/16/avatar.svg"></a>
+<a href="https://opencollective.com/debug/backer/17/website" target="_blank"><img src="https://opencollective.com/debug/backer/17/avatar.svg"></a>
+<a href="https://opencollective.com/debug/backer/18/website" target="_blank"><img src="https://opencollective.com/debug/backer/18/avatar.svg"></a>
+<a href="https://opencollective.com/debug/backer/19/website" target="_blank"><img src="https://opencollective.com/debug/backer/19/avatar.svg"></a>
+<a href="https://opencollective.com/debug/backer/20/website" target="_blank"><img src="https://opencollective.com/debug/backer/20/avatar.svg"></a>
+<a href="https://opencollective.com/debug/backer/21/website" target="_blank"><img src="https://opencollective.com/debug/backer/21/avatar.svg"></a>
+<a href="https://opencollective.com/debug/backer/22/website" target="_blank"><img src="https://opencollective.com/debug/backer/22/avatar.svg"></a>
+<a href="https://opencollective.com/debug/backer/23/website" target="_blank"><img src="https://opencollective.com/debug/backer/23/avatar.svg"></a>
+<a href="https://opencollective.com/debug/backer/24/website" target="_blank"><img src="https://opencollective.com/debug/backer/24/avatar.svg"></a>
+<a href="https://opencollective.com/debug/backer/25/website" target="_blank"><img src="https://opencollective.com/debug/backer/25/avatar.svg"></a>
+<a href="https://opencollective.com/debug/backer/26/website" target="_blank"><img src="https://opencollective.com/debug/backer/26/avatar.svg"></a>
+<a href="https://opencollective.com/debug/backer/27/website" target="_blank"><img src="https://opencollective.com/debug/backer/27/avatar.svg"></a>
+<a href="https://opencollective.com/debug/backer/28/website" target="_blank"><img src="https://opencollective.com/debug/backer/28/avatar.svg"></a>
+<a href="https://opencollective.com/debug/backer/29/website" target="_blank"><img src="https://opencollective.com/debug/backer/29/avatar.svg"></a>
+
+
+## Sponsors
+
+Become a sponsor and get your logo on our README on Github with a link to your site. [[Become a sponsor](https://opencollective.com/debug#sponsor)]
+
+<a href="https://opencollective.com/debug/sponsor/0/website" target="_blank"><img src="https://opencollective.com/debug/sponsor/0/avatar.svg"></a>
+<a href="https://opencollective.com/debug/sponsor/1/website" target="_blank"><img src="https://opencollective.com/debug/sponsor/1/avatar.svg"></a>
+<a href="https://opencollective.com/debug/sponsor/2/website" target="_blank"><img src="https://opencollective.com/debug/sponsor/2/avatar.svg"></a>
+<a href="https://opencollective.com/debug/sponsor/3/website" target="_blank"><img src="https://opencollective.com/debug/sponsor/3/avatar.svg"></a>
+<a href="https://opencollective.com/debug/sponsor/4/website" target="_blank"><img src="https://opencollective.com/debug/sponsor/4/avatar.svg"></a>
+<a href="https://opencollective.com/debug/sponsor/5/website" target="_blank"><img src="https://opencollective.com/debug/sponsor/5/avatar.svg"></a>
+<a href="https://opencollective.com/debug/sponsor/6/website" target="_blank"><img src="https://opencollective.com/debug/sponsor/6/avatar.svg"></a>
+<a href="https://opencollective.com/debug/sponsor/7/website" target="_blank"><img src="https://opencollective.com/debug/sponsor/7/avatar.svg"></a>
+<a href="https://opencollective.com/debug/sponsor/8/website" target="_blank"><img src="https://opencollective.com/debug/sponsor/8/avatar.svg"></a>
+<a href="https://opencollective.com/debug/sponsor/9/website" target="_blank"><img src="https://opencollective.com/debug/sponsor/9/avatar.svg"></a>
+<a href="https://opencollective.com/debug/sponsor/10/website" target="_blank"><img src="https://opencollective.com/debug/sponsor/10/avatar.svg"></a>
+<a href="https://opencollective.com/debug/sponsor/11/website" target="_blank"><img src="https://opencollective.com/debug/sponsor/11/avatar.svg"></a>
+<a href="https://opencollective.com/debug/sponsor/12/website" target="_blank"><img src="https://opencollective.com/debug/sponsor/12/avatar.svg"></a>
+<a href="https://opencollective.com/debug/sponsor/13/website" target="_blank"><img src="https://opencollective.com/debug/sponsor/13/avatar.svg"></a>
+<a href="https://opencollective.com/debug/sponsor/14/website" target="_blank"><img src="https://opencollective.com/debug/sponsor/14/avatar.svg"></a>
+<a href="https://opencollective.com/debug/sponsor/15/website" target="_blank"><img src="https://opencollective.com/debug/sponsor/15/avatar.svg"></a>
+<a href="https://opencollective.com/debug/sponsor/16/website" target="_blank"><img src="https://opencollective.com/debug/sponsor/16/avatar.svg"></a>
+<a href="https://opencollective.com/debug/sponsor/17/website" target="_blank"><img src="https://opencollective.com/debug/sponsor/17/avatar.svg"></a>
+<a href="https://opencollective.com/debug/sponsor/18/website" target="_blank"><img src="https://opencollective.com/debug/sponsor/18/avatar.svg"></a>
+<a href="https://opencollective.com/debug/sponsor/19/website" target="_blank"><img src="https://opencollective.com/debug/sponsor/19/avatar.svg"></a>
+<a href="https://opencollective.com/debug/sponsor/20/website" target="_blank"><img src="https://opencollective.com/debug/sponsor/20/avatar.svg"></a>
+<a href="https://opencollective.com/debug/sponsor/21/website" target="_blank"><img src="https://opencollective.com/debug/sponsor/21/avatar.svg"></a>
+<a href="https://opencollective.com/debug/sponsor/22/website" target="_blank"><img src="https://opencollective.com/debug/sponsor/22/avatar.svg"></a>
+<a href="https://opencollective.com/debug/sponsor/23/website" target="_blank"><img src="https://opencollective.com/debug/sponsor/23/avatar.svg"></a>
+<a href="https://opencollective.com/debug/sponsor/24/website" target="_blank"><img src="https://opencollective.com/debug/sponsor/24/avatar.svg"></a>
+<a href="https://opencollective.com/debug/sponsor/25/website" target="_blank"><img src="https://opencollective.com/debug/sponsor/25/avatar.svg"></a>
+<a href="https://opencollective.com/debug/sponsor/26/website" target="_blank"><img src="https://opencollective.com/debug/sponsor/26/avatar.svg"></a>
+<a href="https://opencollective.com/debug/sponsor/27/website" target="_blank"><img src="https://opencollective.com/debug/sponsor/27/avatar.svg"></a>
+<a href="https://opencollective.com/debug/sponsor/28/website" target="_blank"><img src="https://opencollective.com/debug/sponsor/28/avatar.svg"></a>
+<a href="https://opencollective.com/debug/sponsor/29/website" target="_blank"><img src="https://opencollective.com/debug/sponsor/29/avatar.svg"></a>
+
+## License
+
+(The MIT License)
+
+Copyright (c) 2014-2017 TJ Holowaychuk &lt;tj@vision-media.ca&gt;
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/node_modules/define-properties/README.md
+++ b/node_modules/define-properties/README.md
@@ -1,0 +1,86 @@
+#define-properties <sup>[![Version Badge][npm-version-svg]][package-url]</sup>
+
+[![Build Status][travis-svg]][travis-url]
+[![dependency status][deps-svg]][deps-url]
+[![dev dependency status][dev-deps-svg]][dev-deps-url]
+[![License][license-image]][license-url]
+[![Downloads][downloads-image]][downloads-url]
+
+[![npm badge][npm-badge-png]][package-url]
+
+[![browser support][testling-svg]][testling-url]
+
+Define multiple non-enumerable properties at once. Uses `Object.defineProperty` when available; falls back to standard assignment in older engines.
+Existing properties are not overridden. Accepts a map of property names to a predicate that, when true, force-overrides.
+
+## Example
+
+```js
+var define = require('define-properties');
+var assert = require('assert');
+
+var obj = define({ a: 1, b: 2 }, {
+	a: 10,
+	b: 20,
+	c: 30
+});
+assert(obj.a === 1);
+assert(obj.b === 2);
+assert(obj.c === 30);
+if (define.supportsDescriptors) {
+	assert.deepEqual(Object.keys(obj), ['a', 'b']);
+	assert.deepEqual(Object.getOwnPropertyDescriptor(obj, 'c'), {
+		configurable: true,
+		enumerable: false,
+		value: 30,
+		writable: false
+	});
+}
+```
+
+Then, with predicates:
+```js
+var define = require('define-properties');
+var assert = require('assert');
+
+var obj = define({ a: 1, b: 2, c: 3 }, {
+	a: 10,
+	b: 20,
+	c: 30
+}, {
+	a: function () { return false; },
+	b: function () { return true; }
+});
+assert(obj.a === 1);
+assert(obj.b === 20);
+assert(obj.c === 3);
+if (define.supportsDescriptors) {
+	assert.deepEqual(Object.keys(obj), ['a', 'c']);
+	assert.deepEqual(Object.getOwnPropertyDescriptor(obj, 'b'), {
+		configurable: true,
+		enumerable: false,
+		value: 20,
+		writable: false
+	});
+}
+```
+
+## Tests
+Simply clone the repo, `npm install`, and run `npm test`
+
+[package-url]: https://npmjs.org/package/define-properties
+[npm-version-svg]: http://versionbadg.es/ljharb/define-properties.svg
+[travis-svg]: https://travis-ci.org/ljharb/define-properties.svg
+[travis-url]: https://travis-ci.org/ljharb/define-properties
+[deps-svg]: https://david-dm.org/ljharb/define-properties.svg
+[deps-url]: https://david-dm.org/ljharb/define-properties
+[dev-deps-svg]: https://david-dm.org/ljharb/define-properties/dev-status.svg
+[dev-deps-url]: https://david-dm.org/ljharb/define-properties#info=devDependencies
+[testling-svg]: https://ci.testling.com/ljharb/define-properties.png
+[testling-url]: https://ci.testling.com/ljharb/define-properties
+[npm-badge-png]: https://nodei.co/npm/define-properties.png?downloads=true&stars=true
+[license-image]: http://img.shields.io/npm/l/define-properties.svg
+[license-url]: LICENSE
+[downloads-image]: http://img.shields.io/npm/dm/define-properties.svg
+[downloads-url]: http://npm-stat.com/charts.html?package=define-properties
+

--- a/node_modules/diff/README.md
+++ b/node_modules/diff/README.md
@@ -1,0 +1,211 @@
+# jsdiff
+
+[![Build Status](https://secure.travis-ci.org/kpdecker/jsdiff.svg)](http://travis-ci.org/kpdecker/jsdiff)
+[![Sauce Test Status](https://saucelabs.com/buildstatus/jsdiff)](https://saucelabs.com/u/jsdiff)
+
+A javascript text differencing implementation.
+
+Based on the algorithm proposed in
+["An O(ND) Difference Algorithm and its Variations" (Myers, 1986)](http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.4.6927).
+
+## Installation
+```bash
+npm install diff --save
+```
+or
+```bash
+bower install jsdiff --save
+```
+
+## API
+
+* `JsDiff.diffChars(oldStr, newStr[, options])` - diffs two blocks of text, comparing character by character.
+
+    Returns a list of change objects (See below).
+
+    Options
+    * `ignoreCase`: `true` to ignore casing difference. Defaults to `false`.
+
+* `JsDiff.diffWords(oldStr, newStr[, options])` - diffs two blocks of text, comparing word by word, ignoring whitespace.
+
+    Returns a list of change objects (See below).
+
+    Options
+    * `ignoreCase`: Same as in `diffChars`.
+
+* `JsDiff.diffWordsWithSpace(oldStr, newStr[, options])` - diffs two blocks of text, comparing word by word, treating whitespace as significant.
+
+    Returns a list of change objects (See below).
+
+* `JsDiff.diffLines(oldStr, newStr[, options])` - diffs two blocks of text, comparing line by line.
+
+    Options
+    * `ignoreWhitespace`: `true` to ignore leading and trailing whitespace. This is the same as `diffTrimmedLines`
+    * `newlineIsToken`: `true` to treat newline characters as separate tokens.  This allows for changes to the newline structure to occur independently of the line content and to be treated as such. In general this is the more human friendly form of `diffLines` and `diffLines` is better suited for patches and other computer friendly output.
+
+    Returns a list of change objects (See below).
+
+* `JsDiff.diffTrimmedLines(oldStr, newStr[, options])` - diffs two blocks of text, comparing line by line, ignoring leading and trailing whitespace.
+
+    Returns a list of change objects (See below).
+
+* `JsDiff.diffSentences(oldStr, newStr[, options])` - diffs two blocks of text, comparing sentence by sentence.
+
+    Returns a list of change objects (See below).
+
+* `JsDiff.diffCss(oldStr, newStr[, options])` - diffs two blocks of text, comparing CSS tokens.
+
+    Returns a list of change objects (See below).
+
+* `JsDiff.diffJson(oldObj, newObj[, options])` - diffs two JSON objects, comparing the fields defined on each. The order of fields, etc does not matter in this comparison.
+
+    Returns a list of change objects (See below).
+
+* `JsDiff.diffArrays(oldArr, newArr[, options])` - diffs two arrays, comparing each item for strict equality (===).
+
+    Options
+    * `comparator`: `function(left, right)` for custom equality checks
+
+    Returns a list of change objects (See below).
+
+* `JsDiff.createTwoFilesPatch(oldFileName, newFileName, oldStr, newStr, oldHeader, newHeader)` - creates a unified diff patch.
+
+    Parameters:
+    * `oldFileName` : String to be output in the filename section of the patch for the removals
+    * `newFileName` : String to be output in the filename section of the patch for the additions
+    * `oldStr` : Original string value
+    * `newStr` : New string value
+    * `oldHeader` : Additional information to include in the old file header
+    * `newHeader` : Additional information to include in the new file header
+    * `options` : An object with options. Currently, only `context` is supported and describes how many lines of context should be included.
+
+* `JsDiff.createPatch(fileName, oldStr, newStr, oldHeader, newHeader)` - creates a unified diff patch.
+
+    Just like JsDiff.createTwoFilesPatch, but with oldFileName being equal to newFileName.
+
+
+* `JsDiff.structuredPatch(oldFileName, newFileName, oldStr, newStr, oldHeader, newHeader, options)` - returns an object with an array of hunk objects.
+
+    This method is similar to createTwoFilesPatch, but returns a data structure
+    suitable for further processing. Parameters are the same as createTwoFilesPatch. The data structure returned may look like this:
+
+    ```js
+    {
+      oldFileName: 'oldfile', newFileName: 'newfile',
+      oldHeader: 'header1', newHeader: 'header2',
+      hunks: [{
+        oldStart: 1, oldLines: 3, newStart: 1, newLines: 3,
+        lines: [' line2', ' line3', '-line4', '+line5', '\\ No newline at end of file'],
+      }]
+    }
+    ```
+
+* `JsDiff.applyPatch(source, patch[, options])` - applies a unified diff patch.
+
+    Return a string containing new version of provided data. `patch` may be a string diff or the output from the `parsePatch` or `structuredPatch` methods.
+
+    The optional `options` object may have the following keys:
+
+    - `fuzzFactor`: Number of lines that are allowed to differ before rejecting a patch. Defaults to 0.
+    - `compareLine(lineNumber, line, operation, patchContent)`: Callback used to compare to given lines to determine if they should be considered equal when patching. Defaults to strict equality but may be overridden to provide fuzzier comparison. Should return false if the lines should be rejected.
+
+* `JsDiff.applyPatches(patch, options)` - applies one or more patches.
+
+    This method will iterate over the contents of the patch and apply to data provided through callbacks. The general flow for each patch index is:
+
+    - `options.loadFile(index, callback)` is called. The caller should then load the contents of the file and then pass that to the `callback(err, data)` callback. Passing an `err` will terminate further patch execution.
+    - `options.patched(index, content, callback)` is called once the patch has been applied. `content` will be the return value from `applyPatch`. When it's ready, the caller should call `callback(err)` callback. Passing an `err` will terminate further patch execution.
+
+    Once all patches have been applied or an error occurs, the `options.complete(err)` callback is made.
+
+* `JsDiff.parsePatch(diffStr)` - Parses a patch into structured data
+
+    Return a JSON object representation of the a patch, suitable for use with the `applyPatch` method. This parses to the same structure returned by `JsDiff.structuredPatch`.
+
+* `convertChangesToXML(changes)` - converts a list of changes to a serialized XML format
+
+
+All methods above which accept the optional `callback` method will run in sync mode when that parameter is omitted and in async mode when supplied. This allows for larger diffs without blocking the event loop. This may be passed either directly as the final parameter or as the `callback` field in the `options` object.
+
+### Change Objects
+Many of the methods above return change objects. These objects consist of the following fields:
+
+* `value`: Text content
+* `added`: True if the value was inserted into the new string
+* `removed`: True of the value was removed from the old string
+
+Note that some cases may omit a particular flag field. Comparison on the flag fields should always be done in a truthy or falsy manner.
+
+## Examples
+
+Basic example in Node
+
+```js
+require('colors');
+var jsdiff = require('diff');
+
+var one = 'beep boop';
+var other = 'beep boob blah';
+
+var diff = jsdiff.diffChars(one, other);
+
+diff.forEach(function(part){
+  // green for additions, red for deletions
+  // grey for common parts
+  var color = part.added ? 'green' :
+    part.removed ? 'red' : 'grey';
+  process.stderr.write(part.value[color]);
+});
+
+console.log();
+```
+Running the above program should yield
+
+<img src="images/node_example.png" alt="Node Example">
+
+Basic example in a web page
+
+```html
+<pre id="display"></pre>
+<script src="diff.js"></script>
+<script>
+var one = 'beep boop',
+    other = 'beep boob blah',
+    color = '',
+    span = null;
+
+var diff = JsDiff.diffChars(one, other),
+    display = document.getElementById('display'),
+    fragment = document.createDocumentFragment();
+
+diff.forEach(function(part){
+  // green for additions, red for deletions
+  // grey for common parts
+  color = part.added ? 'green' :
+    part.removed ? 'red' : 'grey';
+  span = document.createElement('span');
+  span.style.color = color;
+  span.appendChild(document
+    .createTextNode(part.value));
+  fragment.appendChild(span);
+});
+
+display.appendChild(fragment);
+</script>
+```
+
+Open the above .html file in a browser and you should see
+
+<img src="images/web_example.png" alt="Node Example">
+
+**[Full online demo](http://kpdecker.github.com/jsdiff)**
+
+## Compatibility
+
+[![Sauce Test Status](https://saucelabs.com/browser-matrix/jsdiff.svg)](https://saucelabs.com/u/jsdiff)
+
+jsdiff supports all ES3 environments with some known issues on IE8 and below. Under these browsers some diff algorithms such as word diff and others may fail due to lack of support for capturing groups in the `split` operation.
+
+## License
+
+See [LICENSE](https://github.com/kpdecker/jsdiff/blob/master/LICENSE).

--- a/node_modules/emoji-regex/README.md
+++ b/node_modules/emoji-regex/README.md
@@ -1,0 +1,73 @@
+# emoji-regex [![Build status](https://travis-ci.org/mathiasbynens/emoji-regex.svg?branch=master)](https://travis-ci.org/mathiasbynens/emoji-regex)
+
+_emoji-regex_ offers a regular expression to match all emoji symbols (including textual representations of emoji) as per the Unicode Standard.
+
+This repository contains a script that generates this regular expression based on [the data from Unicode Technical Report #51](https://github.com/mathiasbynens/unicode-tr51). Because of this, the regular expression can easily be updated whenever new emoji are added to the Unicode standard.
+
+## Installation
+
+Via [npm](https://www.npmjs.com/):
+
+```bash
+npm install emoji-regex
+```
+
+In [Node.js](https://nodejs.org/):
+
+```js
+const emojiRegex = require('emoji-regex');
+// Note: because the regular expression has the global flag set, this module
+// exports a function that returns the regex rather than exporting the regular
+// expression itself, to make it impossible to (accidentally) mutate the
+// original regular expression.
+
+const text = `
+\u{231A}: ⌚ default emoji presentation character (Emoji_Presentation)
+\u{2194}\u{FE0F}: ↔️ default text presentation character rendered as emoji
+\u{1F469}: 👩 emoji modifier base (Emoji_Modifier_Base)
+\u{1F469}\u{1F3FF}: 👩🏿 emoji modifier base followed by a modifier
+`;
+
+const regex = emojiRegex();
+let match;
+while (match = regex.exec(text)) {
+  const emoji = match[0];
+  console.log(`Matched sequence ${ emoji } — code points: ${ [...emoji].length }`);
+}
+```
+
+Console output:
+
+```
+Matched sequence ⌚ — code points: 1
+Matched sequence ⌚ — code points: 1
+Matched sequence ↔️ — code points: 2
+Matched sequence ↔️ — code points: 2
+Matched sequence 👩 — code points: 1
+Matched sequence 👩 — code points: 1
+Matched sequence 👩🏿 — code points: 2
+Matched sequence 👩🏿 — code points: 2
+```
+
+To match emoji in their textual representation as well (i.e. emoji that are not `Emoji_Presentation` symbols and that aren’t forced to render as emoji by a variation selector), `require` the other regex:
+
+```js
+const emojiRegex = require('emoji-regex/text.js');
+```
+
+Additionally, in environments which support ES2015 Unicode escapes, you may `require` ES2015-style versions of the regexes:
+
+```js
+const emojiRegex = require('emoji-regex/es2015/index.js');
+const emojiRegexText = require('emoji-regex/es2015/text.js');
+```
+
+## Author
+
+| [![twitter/mathias](https://gravatar.com/avatar/24e08a9ea84deb17ae121074d0f17125?s=70)](https://twitter.com/mathias "Follow @mathias on Twitter") |
+|---|
+| [Mathias Bynens](https://mathiasbynens.be/) |
+
+## License
+
+_emoji-regex_ is available under the [MIT](https://mths.be/mit) license.

--- a/node_modules/end-of-stream/README.md
+++ b/node_modules/end-of-stream/README.md
@@ -1,0 +1,52 @@
+# end-of-stream
+
+A node module that calls a callback when a readable/writable/duplex stream has completed or failed.
+
+	npm install end-of-stream
+
+## Usage
+
+Simply pass a stream and a callback to the `eos`.
+Both legacy streams, streams2 and stream3 are supported.
+
+``` js
+var eos = require('end-of-stream');
+
+eos(readableStream, function(err) {
+  // this will be set to the stream instance
+	if (err) return console.log('stream had an error or closed early');
+	console.log('stream has ended', this === readableStream);
+});
+
+eos(writableStream, function(err) {
+	if (err) return console.log('stream had an error or closed early');
+	console.log('stream has finished', this === writableStream);
+});
+
+eos(duplexStream, function(err) {
+	if (err) return console.log('stream had an error or closed early');
+	console.log('stream has ended and finished', this === duplexStream);
+});
+
+eos(duplexStream, {readable:false}, function(err) {
+	if (err) return console.log('stream had an error or closed early');
+	console.log('stream has finished but might still be readable');
+});
+
+eos(duplexStream, {writable:false}, function(err) {
+	if (err) return console.log('stream had an error or closed early');
+	console.log('stream has ended but might still be writable');
+});
+
+eos(readableStream, {error:false}, function(err) {
+	// do not treat emit('error', err) as a end-of-stream
+});
+```
+
+## License
+
+MIT
+
+## Related
+
+`end-of-stream` is part of the [mississippi stream utility collection](https://github.com/maxogden/mississippi) which includes more useful stream modules similar to this one.

--- a/node_modules/es-abstract/README.md
+++ b/node_modules/es-abstract/README.md
@@ -1,0 +1,44 @@
+# es-abstract <sup>[![Version Badge][npm-version-svg]][package-url]</sup>
+
+[![Build Status][travis-svg]][travis-url]
+[![dependency status][deps-svg]][deps-url]
+[![dev dependency status][dev-deps-svg]][dev-deps-url]
+[![License][license-image]][license-url]
+[![Downloads][downloads-image]][downloads-url]
+
+[![npm badge][npm-badge-png]][package-url]
+
+[![browser support][testling-svg]][testling-url]
+
+ECMAScript spec abstract operations.
+When different versions of the spec conflict, the default export will be the latest version of the abstract operation.
+All abstract operations will also be available under an `es5`/`es2015`/`es2016`/`es2017`/`es2018` entry point, and exported property, if you require a specific version.
+
+## Example
+
+```js
+var ES = require('es-abstract');
+var assert = require('assert');
+
+assert(ES.isCallable(function () {}));
+assert(!ES.isCallable(/a/g));
+```
+
+## Tests
+Simply clone the repo, `npm install`, and run `npm test`
+
+[package-url]: https://npmjs.org/package/es-abstract
+[npm-version-svg]: http://versionbadg.es/ljharb/es-abstract.svg
+[travis-svg]: https://travis-ci.org/ljharb/es-abstract.svg
+[travis-url]: https://travis-ci.org/ljharb/es-abstract
+[deps-svg]: https://david-dm.org/ljharb/es-abstract.svg
+[deps-url]: https://david-dm.org/ljharb/es-abstract
+[dev-deps-svg]: https://david-dm.org/ljharb/es-abstract/dev-status.svg
+[dev-deps-url]: https://david-dm.org/ljharb/es-abstract#info=devDependencies
+[testling-svg]: https://ci.testling.com/ljharb/es-abstract.png
+[testling-url]: https://ci.testling.com/ljharb/es-abstract
+[npm-badge-png]: https://nodei.co/npm/es-abstract.png?downloads=true&stars=true
+[license-image]: https://img.shields.io/npm/l/es-abstract.svg
+[license-url]: LICENSE
+[downloads-image]: https://img.shields.io/npm/dm/es-abstract.svg
+[downloads-url]: https://npm-stat.com/charts.html?package=es-abstract

--- a/node_modules/es-to-primitive/README.md
+++ b/node_modules/es-to-primitive/README.md
@@ -1,0 +1,51 @@
+# es-to-primitive <sup>[![Version Badge][npm-version-svg]][package-url]</sup>
+
+[![Build Status][travis-svg]][travis-url]
+[![dependency status][deps-svg]][deps-url]
+[![dev dependency status][dev-deps-svg]][dev-deps-url]
+[![License][license-image]][license-url]
+[![Downloads][downloads-image]][downloads-url]
+
+[![npm badge][npm-badge-png]][package-url]
+
+ECMAScript “ToPrimitive” algorithm. Provides ES5 and ES2015 versions.
+When different versions of the spec conflict, the default export will be the latest version of the abstract operation.
+Alternative versions will also be available under an `es5`/`es2015` exported property if you require a specific version.
+
+## Example
+
+```js
+var toPrimitive = require('es-to-primitive');
+var assert = require('assert');
+
+assert(toPrimitive(function () {}) === String(function () {}));
+
+var date = new Date();
+assert(toPrimitive(date) === String(date));
+
+assert(toPrimitive({ valueOf: function () { return 3; } }) === 3);
+
+assert(toPrimitive(['a', 'b', 3]) === String(['a', 'b', 3]));
+
+var sym = Symbol();
+assert(toPrimitive(Object(sym)) === sym);
+```
+
+## Tests
+Simply clone the repo, `npm install`, and run `npm test`
+
+[package-url]: https://npmjs.org/package/es-to-primitive
+[npm-version-svg]: http://versionbadg.es/ljharb/es-to-primitive.svg
+[travis-svg]: https://travis-ci.org/ljharb/es-to-primitive.svg
+[travis-url]: https://travis-ci.org/ljharb/es-to-primitive
+[deps-svg]: https://david-dm.org/ljharb/es-to-primitive.svg
+[deps-url]: https://david-dm.org/ljharb/es-to-primitive
+[dev-deps-svg]: https://david-dm.org/ljharb/es-to-primitive/dev-status.svg
+[dev-deps-url]: https://david-dm.org/ljharb/es-to-primitive#info=devDependencies
+[testling-svg]: https://ci.testling.com/ljharb/es-to-primitive.png
+[testling-url]: https://ci.testling.com/ljharb/es-to-primitive
+[npm-badge-png]: https://nodei.co/npm/es-to-primitive.png?downloads=true&stars=true
+[license-image]: http://img.shields.io/npm/l/es-to-primitive.svg
+[license-url]: LICENSE
+[downloads-image]: http://img.shields.io/npm/dm/es-to-primitive.svg
+[downloads-url]: http://npm-stat.com/charts.html?package=es-to-primitive

--- a/node_modules/esprima/README.md
+++ b/node_modules/esprima/README.md
@@ -1,0 +1,46 @@
+[![NPM version](https://img.shields.io/npm/v/esprima.svg)](https://www.npmjs.com/package/esprima)
+[![npm download](https://img.shields.io/npm/dm/esprima.svg)](https://www.npmjs.com/package/esprima)
+[![Build Status](https://img.shields.io/travis/jquery/esprima/master.svg)](https://travis-ci.org/jquery/esprima)
+[![Coverage Status](https://img.shields.io/codecov/c/github/jquery/esprima/master.svg)](https://codecov.io/github/jquery/esprima)
+
+**Esprima** ([esprima.org](http://esprima.org), BSD license) is a high performance,
+standard-compliant [ECMAScript](http://www.ecma-international.org/publications/standards/Ecma-262.htm)
+parser written in ECMAScript (also popularly known as
+[JavaScript](https://en.wikipedia.org/wiki/JavaScript)).
+Esprima is created and maintained by [Ariya Hidayat](https://twitter.com/ariyahidayat),
+with the help of [many contributors](https://github.com/jquery/esprima/contributors).
+
+### Features
+
+- Full support for ECMAScript 2017 ([ECMA-262 8th Edition](http://www.ecma-international.org/publications/standards/Ecma-262.htm))
+- Sensible [syntax tree format](https://github.com/estree/estree/blob/master/es5.md) as standardized by [ESTree project](https://github.com/estree/estree)
+- Experimental support for [JSX](https://facebook.github.io/jsx/), a syntax extension for [React](https://facebook.github.io/react/)
+- Optional tracking of syntax node location (index-based and line-column)
+- [Heavily tested](http://esprima.org/test/ci.html) (~1500 [unit tests](https://github.com/jquery/esprima/tree/master/test/fixtures) with [full code coverage](https://codecov.io/github/jquery/esprima))
+
+### API
+
+Esprima can be used to perform [lexical analysis](https://en.wikipedia.org/wiki/Lexical_analysis) (tokenization) or [syntactic analysis](https://en.wikipedia.org/wiki/Parsing) (parsing) of a JavaScript program.
+
+A simple example on Node.js REPL:
+
+```javascript
+> var esprima = require('esprima');
+> var program = 'const answer = 42';
+
+> esprima.tokenize(program);
+[ { type: 'Keyword', value: 'const' },
+  { type: 'Identifier', value: 'answer' },
+  { type: 'Punctuator', value: '=' },
+  { type: 'Numeric', value: '42' } ]
+  
+> esprima.parseScript(program);
+{ type: 'Program',
+  body:
+   [ { type: 'VariableDeclaration',
+       declarations: [Object],
+       kind: 'const' } ],
+  sourceType: 'script' }
+```
+
+For more information, please read the [complete documentation](http://esprima.org/doc).

--- a/node_modules/flat/README.md
+++ b/node_modules/flat/README.md
@@ -1,0 +1,187 @@
+# flat [![Build Status](https://secure.travis-ci.org/hughsk/flat.png?branch=master)](http://travis-ci.org/hughsk/flat)
+
+Take a nested Javascript object and flatten it, or unflatten an object with
+delimited keys.
+
+## Installation
+
+``` bash
+$ npm install flat
+```
+
+## Methods
+
+### flatten(original, options)
+
+Flattens the object - it'll return an object one level deep, regardless of how
+nested the original object was:
+
+``` javascript
+var flatten = require('flat')
+
+flatten({
+    key1: {
+        keyA: 'valueI'
+    },
+    key2: {
+        keyB: 'valueII'
+    },
+    key3: { a: { b: { c: 2 } } }
+})
+
+// {
+//   'key1.keyA': 'valueI',
+//   'key2.keyB': 'valueII',
+//   'key3.a.b.c': 2
+// }
+```
+
+### unflatten(original, options)
+
+Flattening is reversible too, you can call `flatten.unflatten()` on an object:
+
+``` javascript
+var unflatten = require('flat').unflatten
+
+unflatten({
+    'three.levels.deep': 42,
+    'three.levels': {
+        nested: true
+    }
+})
+
+// {
+//     three: {
+//         levels: {
+//             deep: 42,
+//             nested: true
+//         }
+//     }
+// }
+```
+
+## Options
+
+### delimiter
+
+Use a custom delimiter for (un)flattening your objects, instead of `.`.
+
+### safe
+
+When enabled, both `flat` and `unflatten` will preserve arrays and their
+contents. This is disabled by default.
+
+``` javascript
+var flatten = require('flat')
+
+flatten({
+    this: [
+        { contains: 'arrays' },
+        { preserving: {
+              them: 'for you'
+        }}
+    ]
+}, {
+    safe: true
+})
+
+// {
+//     'this': [
+//         { contains: 'arrays' },
+//         { preserving: {
+//             them: 'for you'
+//         }}
+//     ]
+// }
+```
+
+### object
+
+When enabled, arrays will not be created automatically when calling unflatten, like so:
+
+``` javascript
+unflatten({
+    'hello.you.0': 'ipsum',
+    'hello.you.1': 'lorem',
+    'hello.other.world': 'foo'
+}, { object: true })
+
+// hello: {
+//     you: {
+//         0: 'ipsum',
+//         1: 'lorem',
+//     },
+//     other: { world: 'foo' }
+// }
+```
+
+### overwrite
+
+When enabled, existing keys in the unflattened object may be overwritten if they cannot hold a newly encountered nested value:
+
+```javascript
+unflatten({
+    'TRAVIS': 'true',
+    'TRAVIS_DIR': '/home/travis/build/kvz/environmental'
+}, { overwrite: true })
+
+// TRAVIS: {
+//     DIR: '/home/travis/build/kvz/environmental'
+// }
+```
+
+Without `overwrite` set to `true`, the `TRAVIS` key would already have been set to a string, thus could not accept the nested `DIR` element.
+
+This only makes sense on ordered arrays, and since we're overwriting data, should be used with care.
+
+
+### maxDepth
+
+Maximum number of nested objects to flatten.
+
+``` javascript
+var flatten = require('flat')
+
+flatten({
+    key1: {
+        keyA: 'valueI'
+    },
+    key2: {
+        keyB: 'valueII'
+    },
+    key3: { a: { b: { c: 2 } } }
+}, { maxDepth: 2 })
+
+// {
+//   'key1.keyA': 'valueI',
+//   'key2.keyB': 'valueII',
+//   'key3.a': { b: { c: 2 } }
+// }
+```
+
+## Command Line Usage
+
+`flat` is also available as a command line tool. You can run it with 
+[`npx`](https://ghub.io/npx):
+
+```sh
+npx flat foo.json
+```
+
+Or install the `flat` command globally:
+ 
+```sh
+npm i -g flat && flat foo.json
+```
+
+Accepts a filename as an argument:
+
+```sh
+flat foo.json
+```
+
+Also accepts JSON on stdin:
+
+```sh
+cat foo.json | flat
+```

--- a/node_modules/fs.realpath/README.md
+++ b/node_modules/fs.realpath/README.md
@@ -1,0 +1,33 @@
+# fs.realpath
+
+A backwards-compatible fs.realpath for Node v6 and above
+
+In Node v6, the JavaScript implementation of fs.realpath was replaced
+with a faster (but less resilient) native implementation.  That raises
+new and platform-specific errors and cannot handle long or excessively
+symlink-looping paths.
+
+This module handles those cases by detecting the new errors and
+falling back to the JavaScript implementation.  On versions of Node
+prior to v6, it has no effect.
+
+## USAGE
+
+```js
+var rp = require('fs.realpath')
+
+// async version
+rp.realpath(someLongAndLoopingPath, function (er, real) {
+  // the ELOOP was handled, but it was a bit slower
+})
+
+// sync version
+var real = rp.realpathSync(someLongAndLoopingPath)
+
+// monkeypatch at your own risk!
+// This replaces the fs.realpath/fs.realpathSync builtins
+rp.monkeypatch()
+
+// un-do the monkeypatching
+rp.unmonkeypatch()
+```

--- a/node_modules/function-bind/README.md
+++ b/node_modules/function-bind/README.md
@@ -1,0 +1,48 @@
+# function-bind
+
+<!--
+    [![build status][travis-svg]][travis-url]
+    [![NPM version][npm-badge-svg]][npm-url]
+    [![Coverage Status][5]][6]
+    [![gemnasium Dependency Status][7]][8]
+    [![Dependency status][deps-svg]][deps-url]
+    [![Dev Dependency status][dev-deps-svg]][dev-deps-url]
+-->
+
+<!-- [![browser support][11]][12] -->
+
+Implementation of function.prototype.bind
+
+## Example
+
+I mainly do this for unit tests I run on phantomjs.
+PhantomJS does not have Function.prototype.bind :(
+
+```js
+Function.prototype.bind = require("function-bind")
+```
+
+## Installation
+
+`npm install function-bind`
+
+## Contributors
+
+ - Raynos
+
+## MIT Licenced
+
+  [travis-svg]: https://travis-ci.org/Raynos/function-bind.svg
+  [travis-url]: https://travis-ci.org/Raynos/function-bind
+  [npm-badge-svg]: https://badge.fury.io/js/function-bind.svg
+  [npm-url]: https://npmjs.org/package/function-bind
+  [5]: https://coveralls.io/repos/Raynos/function-bind/badge.png
+  [6]: https://coveralls.io/r/Raynos/function-bind
+  [7]: https://gemnasium.com/Raynos/function-bind.png
+  [8]: https://gemnasium.com/Raynos/function-bind
+  [deps-svg]: https://david-dm.org/Raynos/function-bind.svg
+  [deps-url]: https://david-dm.org/Raynos/function-bind
+  [dev-deps-svg]: https://david-dm.org/Raynos/function-bind/dev-status.svg
+  [dev-deps-url]: https://david-dm.org/Raynos/function-bind#info=devDependencies
+  [11]: https://ci.testling.com/Raynos/function-bind.png
+  [12]: https://ci.testling.com/Raynos/function-bind

--- a/node_modules/get-caller-file/README.md
+++ b/node_modules/get-caller-file/README.md
@@ -1,0 +1,41 @@
+# get-caller-file
+
+[![Build Status](https://travis-ci.org/stefanpenner/get-caller-file.svg?branch=master)](https://travis-ci.org/stefanpenner/get-caller-file)
+[![Build status](https://ci.appveyor.com/api/projects/status/ol2q94g1932cy14a/branch/master?svg=true)](https://ci.appveyor.com/project/embercli/get-caller-file/branch/master)
+
+This is a utility, which allows a function to figure out from which file it was invoked. It does so by inspecting v8's stack trace at the time it is invoked.
+
+Inspired by http://stackoverflow.com/questions/13227489
+
+*note: this relies on Node/V8 specific APIs, as such other runtimes may not work*
+
+## Installation
+
+```bash
+yarn add get-caller-file
+```
+
+## Usage
+
+Given:
+
+```js
+// ./foo.js
+const getCallerFile = require('get-caller-file');
+
+module.exports = function() {
+  return getCallerFile(); // figures out who called it
+};
+```
+
+```js
+// index.js
+const foo = require('./foo');
+
+foo() // => /full/path/to/this/file/index.js
+```
+
+
+## Options:
+
+* `getCallerFile(position = 2)`: where position is stack frame whos fileName we want.

--- a/node_modules/glob/README.md
+++ b/node_modules/glob/README.md
@@ -1,0 +1,368 @@
+# Glob
+
+Match files using the patterns the shell uses, like stars and stuff.
+
+[![Build Status](https://travis-ci.org/isaacs/node-glob.svg?branch=master)](https://travis-ci.org/isaacs/node-glob/) [![Build Status](https://ci.appveyor.com/api/projects/status/kd7f3yftf7unxlsx?svg=true)](https://ci.appveyor.com/project/isaacs/node-glob) [![Coverage Status](https://coveralls.io/repos/isaacs/node-glob/badge.svg?branch=master&service=github)](https://coveralls.io/github/isaacs/node-glob?branch=master)
+
+This is a glob implementation in JavaScript.  It uses the `minimatch`
+library to do its matching.
+
+![](oh-my-glob.gif)
+
+## Usage
+
+Install with npm
+
+```
+npm i glob
+```
+
+```javascript
+var glob = require("glob")
+
+// options is optional
+glob("**/*.js", options, function (er, files) {
+  // files is an array of filenames.
+  // If the `nonull` option is set, and nothing
+  // was found, then files is ["**/*.js"]
+  // er is an error object or null.
+})
+```
+
+## Glob Primer
+
+"Globs" are the patterns you type when you do stuff like `ls *.js` on
+the command line, or put `build/*` in a `.gitignore` file.
+
+Before parsing the path part patterns, braced sections are expanded
+into a set.  Braced sections start with `{` and end with `}`, with any
+number of comma-delimited sections within.  Braced sections may contain
+slash characters, so `a{/b/c,bcd}` would expand into `a/b/c` and `abcd`.
+
+The following characters have special magic meaning when used in a
+path portion:
+
+* `*` Matches 0 or more characters in a single path portion
+* `?` Matches 1 character
+* `[...]` Matches a range of characters, similar to a RegExp range.
+  If the first character of the range is `!` or `^` then it matches
+  any character not in the range.
+* `!(pattern|pattern|pattern)` Matches anything that does not match
+  any of the patterns provided.
+* `?(pattern|pattern|pattern)` Matches zero or one occurrence of the
+  patterns provided.
+* `+(pattern|pattern|pattern)` Matches one or more occurrences of the
+  patterns provided.
+* `*(a|b|c)` Matches zero or more occurrences of the patterns provided
+* `@(pattern|pat*|pat?erN)` Matches exactly one of the patterns
+  provided
+* `**` If a "globstar" is alone in a path portion, then it matches
+  zero or more directories and subdirectories searching for matches.
+  It does not crawl symlinked directories.
+
+### Dots
+
+If a file or directory path portion has a `.` as the first character,
+then it will not match any glob pattern unless that pattern's
+corresponding path part also has a `.` as its first character.
+
+For example, the pattern `a/.*/c` would match the file at `a/.b/c`.
+However the pattern `a/*/c` would not, because `*` does not start with
+a dot character.
+
+You can make glob treat dots as normal characters by setting
+`dot:true` in the options.
+
+### Basename Matching
+
+If you set `matchBase:true` in the options, and the pattern has no
+slashes in it, then it will seek for any file anywhere in the tree
+with a matching basename.  For example, `*.js` would match
+`test/simple/basic.js`.
+
+### Empty Sets
+
+If no matching files are found, then an empty array is returned.  This
+differs from the shell, where the pattern itself is returned.  For
+example:
+
+    $ echo a*s*d*f
+    a*s*d*f
+
+To get the bash-style behavior, set the `nonull:true` in the options.
+
+### See Also:
+
+* `man sh`
+* `man bash` (Search for "Pattern Matching")
+* `man 3 fnmatch`
+* `man 5 gitignore`
+* [minimatch documentation](https://github.com/isaacs/minimatch)
+
+## glob.hasMagic(pattern, [options])
+
+Returns `true` if there are any special characters in the pattern, and
+`false` otherwise.
+
+Note that the options affect the results.  If `noext:true` is set in
+the options object, then `+(a|b)` will not be considered a magic
+pattern.  If the pattern has a brace expansion, like `a/{b/c,x/y}`
+then that is considered magical, unless `nobrace:true` is set in the
+options.
+
+## glob(pattern, [options], cb)
+
+* `pattern` `{String}` Pattern to be matched
+* `options` `{Object}`
+* `cb` `{Function}`
+  * `err` `{Error | null}`
+  * `matches` `{Array<String>}` filenames found matching the pattern
+
+Perform an asynchronous glob search.
+
+## glob.sync(pattern, [options])
+
+* `pattern` `{String}` Pattern to be matched
+* `options` `{Object}`
+* return: `{Array<String>}` filenames found matching the pattern
+
+Perform a synchronous glob search.
+
+## Class: glob.Glob
+
+Create a Glob object by instantiating the `glob.Glob` class.
+
+```javascript
+var Glob = require("glob").Glob
+var mg = new Glob(pattern, options, cb)
+```
+
+It's an EventEmitter, and starts walking the filesystem to find matches
+immediately.
+
+### new glob.Glob(pattern, [options], [cb])
+
+* `pattern` `{String}` pattern to search for
+* `options` `{Object}`
+* `cb` `{Function}` Called when an error occurs, or matches are found
+  * `err` `{Error | null}`
+  * `matches` `{Array<String>}` filenames found matching the pattern
+
+Note that if the `sync` flag is set in the options, then matches will
+be immediately available on the `g.found` member.
+
+### Properties
+
+* `minimatch` The minimatch object that the glob uses.
+* `options` The options object passed in.
+* `aborted` Boolean which is set to true when calling `abort()`.  There
+  is no way at this time to continue a glob search after aborting, but
+  you can re-use the statCache to avoid having to duplicate syscalls.
+* `cache` Convenience object.  Each field has the following possible
+  values:
+  * `false` - Path does not exist
+  * `true` - Path exists
+  * `'FILE'` - Path exists, and is not a directory
+  * `'DIR'` - Path exists, and is a directory
+  * `[file, entries, ...]` - Path exists, is a directory, and the
+    array value is the results of `fs.readdir`
+* `statCache` Cache of `fs.stat` results, to prevent statting the same
+  path multiple times.
+* `symlinks` A record of which paths are symbolic links, which is
+  relevant in resolving `**` patterns.
+* `realpathCache` An optional object which is passed to `fs.realpath`
+  to minimize unnecessary syscalls.  It is stored on the instantiated
+  Glob object, and may be re-used.
+
+### Events
+
+* `end` When the matching is finished, this is emitted with all the
+  matches found.  If the `nonull` option is set, and no match was found,
+  then the `matches` list contains the original pattern.  The matches
+  are sorted, unless the `nosort` flag is set.
+* `match` Every time a match is found, this is emitted with the specific
+  thing that matched. It is not deduplicated or resolved to a realpath.
+* `error` Emitted when an unexpected error is encountered, or whenever
+  any fs error occurs if `options.strict` is set.
+* `abort` When `abort()` is called, this event is raised.
+
+### Methods
+
+* `pause` Temporarily stop the search
+* `resume` Resume the search
+* `abort` Stop the search forever
+
+### Options
+
+All the options that can be passed to Minimatch can also be passed to
+Glob to change pattern matching behavior.  Also, some have been added,
+or have glob-specific ramifications.
+
+All options are false by default, unless otherwise noted.
+
+All options are added to the Glob object, as well.
+
+If you are running many `glob` operations, you can pass a Glob object
+as the `options` argument to a subsequent operation to shortcut some
+`stat` and `readdir` calls.  At the very least, you may pass in shared
+`symlinks`, `statCache`, `realpathCache`, and `cache` options, so that
+parallel glob operations will be sped up by sharing information about
+the filesystem.
+
+* `cwd` The current working directory in which to search.  Defaults
+  to `process.cwd()`.
+* `root` The place where patterns starting with `/` will be mounted
+  onto.  Defaults to `path.resolve(options.cwd, "/")` (`/` on Unix
+  systems, and `C:\` or some such on Windows.)
+* `dot` Include `.dot` files in normal matches and `globstar` matches.
+  Note that an explicit dot in a portion of the pattern will always
+  match dot files.
+* `nomount` By default, a pattern starting with a forward-slash will be
+  "mounted" onto the root setting, so that a valid filesystem path is
+  returned.  Set this flag to disable that behavior.
+* `mark` Add a `/` character to directory matches.  Note that this
+  requires additional stat calls.
+* `nosort` Don't sort the results.
+* `stat` Set to true to stat *all* results.  This reduces performance
+  somewhat, and is completely unnecessary, unless `readdir` is presumed
+  to be an untrustworthy indicator of file existence.
+* `silent` When an unusual error is encountered when attempting to
+  read a directory, a warning will be printed to stderr.  Set the
+  `silent` option to true to suppress these warnings.
+* `strict` When an unusual error is encountered when attempting to
+  read a directory, the process will just continue on in search of
+  other matches.  Set the `strict` option to raise an error in these
+  cases.
+* `cache` See `cache` property above.  Pass in a previously generated
+  cache object to save some fs calls.
+* `statCache` A cache of results of filesystem information, to prevent
+  unnecessary stat calls.  While it should not normally be necessary
+  to set this, you may pass the statCache from one glob() call to the
+  options object of another, if you know that the filesystem will not
+  change between calls.  (See "Race Conditions" below.)
+* `symlinks` A cache of known symbolic links.  You may pass in a
+  previously generated `symlinks` object to save `lstat` calls when
+  resolving `**` matches.
+* `sync` DEPRECATED: use `glob.sync(pattern, opts)` instead.
+* `nounique` In some cases, brace-expanded patterns can result in the
+  same file showing up multiple times in the result set.  By default,
+  this implementation prevents duplicates in the result set.  Set this
+  flag to disable that behavior.
+* `nonull` Set to never return an empty set, instead returning a set
+  containing the pattern itself.  This is the default in glob(3).
+* `debug` Set to enable debug logging in minimatch and glob.
+* `nobrace` Do not expand `{a,b}` and `{1..3}` brace sets.
+* `noglobstar` Do not match `**` against multiple filenames.  (Ie,
+  treat it as a normal `*` instead.)
+* `noext` Do not match `+(a|b)` "extglob" patterns.
+* `nocase` Perform a case-insensitive match.  Note: on
+  case-insensitive filesystems, non-magic patterns will match by
+  default, since `stat` and `readdir` will not raise errors.
+* `matchBase` Perform a basename-only match if the pattern does not
+  contain any slash characters.  That is, `*.js` would be treated as
+  equivalent to `**/*.js`, matching all js files in all directories.
+* `nodir` Do not match directories, only files.  (Note: to match
+  *only* directories, simply put a `/` at the end of the pattern.)
+* `ignore` Add a pattern or an array of glob patterns to exclude matches.
+  Note: `ignore` patterns are *always* in `dot:true` mode, regardless
+  of any other settings.
+* `follow` Follow symlinked directories when expanding `**` patterns.
+  Note that this can result in a lot of duplicate references in the
+  presence of cyclic links.
+* `realpath` Set to true to call `fs.realpath` on all of the results.
+  In the case of a symlink that cannot be resolved, the full absolute
+  path to the matched entry is returned (though it will usually be a
+  broken symlink)
+* `absolute` Set to true to always receive absolute paths for matched
+  files.  Unlike `realpath`, this also affects the values returned in
+  the `match` event.
+
+## Comparisons to other fnmatch/glob implementations
+
+While strict compliance with the existing standards is a worthwhile
+goal, some discrepancies exist between node-glob and other
+implementations, and are intentional.
+
+The double-star character `**` is supported by default, unless the
+`noglobstar` flag is set.  This is supported in the manner of bsdglob
+and bash 4.3, where `**` only has special significance if it is the only
+thing in a path part.  That is, `a/**/b` will match `a/x/y/b`, but
+`a/**b` will not.
+
+Note that symlinked directories are not crawled as part of a `**`,
+though their contents may match against subsequent portions of the
+pattern.  This prevents infinite loops and duplicates and the like.
+
+If an escaped pattern has no matches, and the `nonull` flag is set,
+then glob returns the pattern as-provided, rather than
+interpreting the character escapes.  For example,
+`glob.match([], "\\*a\\?")` will return `"\\*a\\?"` rather than
+`"*a?"`.  This is akin to setting the `nullglob` option in bash, except
+that it does not resolve escaped pattern characters.
+
+If brace expansion is not disabled, then it is performed before any
+other interpretation of the glob pattern.  Thus, a pattern like
+`+(a|{b),c)}`, which would not be valid in bash or zsh, is expanded
+**first** into the set of `+(a|b)` and `+(a|c)`, and those patterns are
+checked for validity.  Since those two are valid, matching proceeds.
+
+### Comments and Negation
+
+Previously, this module let you mark a pattern as a "comment" if it
+started with a `#` character, or a "negated" pattern if it started
+with a `!` character.
+
+These options were deprecated in version 5, and removed in version 6.
+
+To specify things that should not match, use the `ignore` option.
+
+## Windows
+
+**Please only use forward-slashes in glob expressions.**
+
+Though windows uses either `/` or `\` as its path separator, only `/`
+characters are used by this glob implementation.  You must use
+forward-slashes **only** in glob expressions.  Back-slashes will always
+be interpreted as escape characters, not path separators.
+
+Results from absolute patterns such as `/foo/*` are mounted onto the
+root setting using `path.join`.  On windows, this will by default result
+in `/foo/*` matching `C:\foo\bar.txt`.
+
+## Race Conditions
+
+Glob searching, by its very nature, is susceptible to race conditions,
+since it relies on directory walking and such.
+
+As a result, it is possible that a file that exists when glob looks for
+it may have been deleted or modified by the time it returns the result.
+
+As part of its internal implementation, this program caches all stat
+and readdir calls that it makes, in order to cut down on system
+overhead.  However, this also makes it even more susceptible to races,
+especially if the cache or statCache objects are reused between glob
+calls.
+
+Users are thus advised not to use a glob result as a guarantee of
+filesystem state in the face of rapid changes.  For the vast majority
+of operations, this is never a problem.
+
+## Contributing
+
+Any change to behavior (including bugfixes) must come with a test.
+
+Patches that fail tests or reduce performance will be rejected.
+
+```
+# to run tests
+npm test
+
+# to re-generate test fixtures
+npm run test-regen
+
+# to benchmark against bash/zsh
+npm run bench
+
+# to profile javascript
+npm run prof
+```

--- a/node_modules/has-symbols/README.md
+++ b/node_modules/has-symbols/README.md
@@ -1,0 +1,45 @@
+# has-symbols <sup>[![Version Badge][2]][1]</sup>
+
+[![Build Status][3]][4]
+[![dependency status][5]][6]
+[![dev dependency status][7]][8]
+[![License][license-image]][license-url]
+[![Downloads][downloads-image]][downloads-url]
+
+[![npm badge][11]][1]
+
+Determine if the JS environment has Symbol support. Supports spec, or shams.
+
+## Example
+
+```js
+var hasSymbols = require('has-symbols');
+
+hasSymbols() === true; // if the environment has native Symbol support. Not polyfillable, not forgeable.
+
+var hasSymbolsKinda = require('has-symbols/shams');
+hasSymbolsKinda() === true; // if the environment has a Symbol sham that mostly follows the spec.
+```
+
+## Supported Symbol shams
+ - get-own-property-symbols [npm](https://www.npmjs.com/package/get-own-property-symbols) | [github](https://github.com/WebReflection/get-own-property-symbols)
+ - core-js [npm](https://www.npmjs.com/package/core-js) | [github](https://github.com/zloirock/core-js)
+
+## Tests
+Simply clone the repo, `npm install`, and run `npm test`
+
+[1]: https://npmjs.org/package/has-symbols
+[2]: http://versionbadg.es/ljharb/has-symbols.svg
+[3]: https://travis-ci.org/ljharb/has-symbols.svg
+[4]: https://travis-ci.org/ljharb/has-symbols
+[5]: https://david-dm.org/ljharb/has-symbols.svg
+[6]: https://david-dm.org/ljharb/has-symbols
+[7]: https://david-dm.org/ljharb/has-symbols/dev-status.svg
+[8]: https://david-dm.org/ljharb/has-symbols#info=devDependencies
+[9]: https://ci.testling.com/ljharb/has-symbols.png
+[10]: https://ci.testling.com/ljharb/has-symbols
+[11]: https://nodei.co/npm/has-symbols.png?downloads=true&stars=true
+[license-image]: http://img.shields.io/npm/l/has-symbols.svg
+[license-url]: LICENSE
+[downloads-image]: http://img.shields.io/npm/dm/has-symbols.svg
+[downloads-url]: http://npm-stat.com/charts.html?package=has-symbols

--- a/node_modules/has/README.md
+++ b/node_modules/has/README.md
@@ -1,0 +1,18 @@
+# has
+
+> Object.prototype.hasOwnProperty.call shortcut
+
+## Installation
+
+```sh
+npm install --save has
+```
+
+## Usage
+
+```js
+var has = require('has');
+
+has({}, 'hasOwnProperty'); // false
+has(Object.prototype, 'hasOwnProperty'); // true
+```

--- a/node_modules/he/README.md
+++ b/node_modules/he/README.md
@@ -1,0 +1,379 @@
+# he [![Build status](https://travis-ci.org/mathiasbynens/he.svg?branch=master)](https://travis-ci.org/mathiasbynens/he) [![Code coverage status](https://codecov.io/github/mathiasbynens/he/coverage.svg?branch=master)](https://codecov.io/github/mathiasbynens/he?branch=master) [![Dependency status](https://gemnasium.com/mathiasbynens/he.svg)](https://gemnasium.com/mathiasbynens/he)
+
+_he_ (for “HTML entities”) is a robust HTML entity encoder/decoder written in JavaScript. It supports [all standardized named character references as per HTML](https://html.spec.whatwg.org/multipage/syntax.html#named-character-references), handles [ambiguous ampersands](https://mathiasbynens.be/notes/ambiguous-ampersands) and other edge cases [just like a browser would](https://html.spec.whatwg.org/multipage/syntax.html#tokenizing-character-references), has an extensive test suite, and — contrary to many other JavaScript solutions — _he_ handles astral Unicode symbols just fine. [An online demo is available.](https://mothereff.in/html-entities)
+
+## Installation
+
+Via [npm](https://www.npmjs.com/):
+
+```bash
+npm install he
+```
+
+Via [Bower](http://bower.io/):
+
+```bash
+bower install he
+```
+
+Via [Component](https://github.com/component/component):
+
+```bash
+component install mathiasbynens/he
+```
+
+In a browser:
+
+```html
+<script src="he.js"></script>
+```
+
+In [Node.js](https://nodejs.org/), [io.js](https://iojs.org/), [Narwhal](http://narwhaljs.org/), and [RingoJS](http://ringojs.org/):
+
+```js
+var he = require('he');
+```
+
+In [Rhino](http://www.mozilla.org/rhino/):
+
+```js
+load('he.js');
+```
+
+Using an AMD loader like [RequireJS](http://requirejs.org/):
+
+```js
+require(
+  {
+    'paths': {
+      'he': 'path/to/he'
+    }
+  },
+  ['he'],
+  function(he) {
+    console.log(he);
+  }
+);
+```
+
+## API
+
+### `he.version`
+
+A string representing the semantic version number.
+
+### `he.encode(text, options)`
+
+This function takes a string of text and encodes (by default) any symbols that aren’t printable ASCII symbols and `&`, `<`, `>`, `"`, `'`, and `` ` ``, replacing them with character references.
+
+```js
+he.encode('foo © bar ≠ baz 𝌆 qux');
+// → 'foo &#xA9; bar &#x2260; baz &#x1D306; qux'
+```
+
+As long as the input string contains [allowed code points](https://html.spec.whatwg.org/multipage/parsing.html#preprocessing-the-input-stream) only, the return value of this function is always valid HTML. Any [(invalid) code points that cannot be represented using a character reference](https://html.spec.whatwg.org/multipage/syntax.html#table-charref-overrides) in the input are not encoded:
+
+```js
+he.encode('foo \0 bar');
+// → 'foo \0 bar'
+```
+
+However, enabling [the `strict` option](https://github.com/mathiasbynens/he#strict) causes invalid code points to throw an exception. With `strict` enabled, `he.encode` either throws (if the input contains invalid code points) or returns a string of valid HTML.
+
+The `options` object is optional. It recognizes the following properties:
+
+#### `useNamedReferences`
+
+The default value for the `useNamedReferences` option is `false`. This means that `encode()` will not use any named character references (e.g. `&copy;`) in the output — hexadecimal escapes (e.g. `&#xA9;`) will be used instead. Set it to `true` to enable the use of named references.
+
+**Note that if compatibility with older browsers is a concern, this option should remain disabled.**
+
+```js
+// Using the global default setting (defaults to `false`):
+he.encode('foo © bar ≠ baz 𝌆 qux');
+// → 'foo &#xA9; bar &#x2260; baz &#x1D306; qux'
+
+// Passing an `options` object to `encode`, to explicitly disallow named references:
+he.encode('foo © bar ≠ baz 𝌆 qux', {
+  'useNamedReferences': false
+});
+// → 'foo &#xA9; bar &#x2260; baz &#x1D306; qux'
+
+// Passing an `options` object to `encode`, to explicitly allow named references:
+he.encode('foo © bar ≠ baz 𝌆 qux', {
+  'useNamedReferences': true
+});
+// → 'foo &copy; bar &ne; baz &#x1D306; qux'
+```
+
+#### `decimal`
+
+The default value for the `decimal` option is `false`. If the option is enabled, `encode` will generally use decimal escapes (e.g. `&#169;`) rather than hexadecimal escapes (e.g. `&#xA9;`). Beside of this replacement, the basic behavior remains the same when combined with other options. For example: if both options `useNamedReferences` and `decimal` are enabled, named references (e.g. `&copy;`) are used over decimal escapes. HTML entities without a named reference are encoded using decimal escapes.
+
+```js
+// Using the global default setting (defaults to `false`):
+he.encode('foo © bar ≠ baz 𝌆 qux');
+// → 'foo &#xA9; bar &#x2260; baz &#x1D306; qux'
+
+// Passing an `options` object to `encode`, to explicitly disable decimal escapes:
+he.encode('foo © bar ≠ baz 𝌆 qux', {
+  'decimal': false
+});
+// → 'foo &#xA9; bar &#x2260; baz &#x1D306; qux'
+
+// Passing an `options` object to `encode`, to explicitly enable decimal escapes:
+he.encode('foo © bar ≠ baz 𝌆 qux', {
+  'decimal': true
+});
+// → 'foo &#169; bar &#8800; baz &#119558; qux'
+
+// Passing an `options` object to `encode`, to explicitly allow named references and decimal escapes:
+he.encode('foo © bar ≠ baz 𝌆 qux', {
+  'useNamedReferences': true,
+  'decimal': true
+});
+// → 'foo &copy; bar &ne; baz &#119558; qux'
+```
+
+#### `encodeEverything`
+
+The default value for the `encodeEverything` option is `false`. This means that `encode()` will not use any character references for printable ASCII symbols that don’t need escaping. Set it to `true` to encode every symbol in the input string. When set to `true`, this option takes precedence over `allowUnsafeSymbols` (i.e. setting the latter to `true` in such a case has no effect).
+
+```js
+// Using the global default setting (defaults to `false`):
+he.encode('foo © bar ≠ baz 𝌆 qux');
+// → 'foo &#xA9; bar &#x2260; baz &#x1D306; qux'
+
+// Passing an `options` object to `encode`, to explicitly encode all symbols:
+he.encode('foo © bar ≠ baz 𝌆 qux', {
+  'encodeEverything': true
+});
+// → '&#x66;&#x6F;&#x6F;&#x20;&#xA9;&#x20;&#x62;&#x61;&#x72;&#x20;&#x2260;&#x20;&#x62;&#x61;&#x7A;&#x20;&#x1D306;&#x20;&#x71;&#x75;&#x78;'
+
+// This setting can be combined with the `useNamedReferences` option:
+he.encode('foo © bar ≠ baz 𝌆 qux', {
+  'encodeEverything': true,
+  'useNamedReferences': true
+});
+// → '&#x66;&#x6F;&#x6F;&#x20;&copy;&#x20;&#x62;&#x61;&#x72;&#x20;&ne;&#x20;&#x62;&#x61;&#x7A;&#x20;&#x1D306;&#x20;&#x71;&#x75;&#x78;'
+```
+
+#### `strict`
+
+The default value for the `strict` option is `false`. This means that `encode()` will encode any HTML text content you feed it, even if it contains any symbols that cause [parse errors](https://html.spec.whatwg.org/multipage/parsing.html#preprocessing-the-input-stream). To throw an error when such invalid HTML is encountered, set the `strict` option to `true`. This option makes it possible to use _he_ as part of HTML parsers and HTML validators.
+
+```js
+// Using the global default setting (defaults to `false`, i.e. error-tolerant mode):
+he.encode('\x01');
+// → '&#x1;'
+
+// Passing an `options` object to `encode`, to explicitly enable error-tolerant mode:
+he.encode('\x01', {
+  'strict': false
+});
+// → '&#x1;'
+
+// Passing an `options` object to `encode`, to explicitly enable strict mode:
+he.encode('\x01', {
+  'strict': true
+});
+// → Parse error
+```
+
+#### `allowUnsafeSymbols`
+
+The default value for the `allowUnsafeSymbols` option is `false`. This means that characters that are unsafe for use in HTML content (`&`, `<`, `>`, `"`, `'`, and `` ` ``) will be encoded. When set to `true`, only non-ASCII characters will be encoded. If the `encodeEverything` option is set to `true`, this option will be ignored.
+
+```js
+he.encode('foo © and & ampersand', {
+  'allowUnsafeSymbols': true
+});
+// → 'foo &#xA9; and & ampersand'
+```
+
+#### Overriding default `encode` options globally
+
+The global default setting can be overridden by modifying the `he.encode.options` object. This saves you from passing in an `options` object for every call to `encode` if you want to use the non-default setting.
+
+```js
+// Read the global default setting:
+he.encode.options.useNamedReferences;
+// → `false` by default
+
+// Override the global default setting:
+he.encode.options.useNamedReferences = true;
+
+// Using the global default setting, which is now `true`:
+he.encode('foo © bar ≠ baz 𝌆 qux');
+// → 'foo &copy; bar &ne; baz &#x1D306; qux'
+```
+
+### `he.decode(html, options)`
+
+This function takes a string of HTML and decodes any named and numerical character references in it using [the algorithm described in section 12.2.4.69 of the HTML spec](https://html.spec.whatwg.org/multipage/syntax.html#tokenizing-character-references).
+
+```js
+he.decode('foo &copy; bar &ne; baz &#x1D306; qux');
+// → 'foo © bar ≠ baz 𝌆 qux'
+```
+
+The `options` object is optional. It recognizes the following properties:
+
+#### `isAttributeValue`
+
+The default value for the `isAttributeValue` option is `false`. This means that `decode()` will decode the string as if it were used in [a text context in an HTML document](https://html.spec.whatwg.org/multipage/syntax.html#data-state). HTML has different rules for [parsing character references in attribute values](https://html.spec.whatwg.org/multipage/syntax.html#character-reference-in-attribute-value-state) — set this option to `true` to treat the input string as if it were used as an attribute value.
+
+```js
+// Using the global default setting (defaults to `false`, i.e. HTML text context):
+he.decode('foo&ampbar');
+// → 'foo&bar'
+
+// Passing an `options` object to `decode`, to explicitly assume an HTML text context:
+he.decode('foo&ampbar', {
+  'isAttributeValue': false
+});
+// → 'foo&bar'
+
+// Passing an `options` object to `decode`, to explicitly assume an HTML attribute value context:
+he.decode('foo&ampbar', {
+  'isAttributeValue': true
+});
+// → 'foo&ampbar'
+```
+
+#### `strict`
+
+The default value for the `strict` option is `false`. This means that `decode()` will decode any HTML text content you feed it, even if it contains any entities that cause [parse errors](https://html.spec.whatwg.org/multipage/syntax.html#tokenizing-character-references). To throw an error when such invalid HTML is encountered, set the `strict` option to `true`. This option makes it possible to use _he_ as part of HTML parsers and HTML validators.
+
+```js
+// Using the global default setting (defaults to `false`, i.e. error-tolerant mode):
+he.decode('foo&ampbar');
+// → 'foo&bar'
+
+// Passing an `options` object to `decode`, to explicitly enable error-tolerant mode:
+he.decode('foo&ampbar', {
+  'strict': false
+});
+// → 'foo&bar'
+
+// Passing an `options` object to `decode`, to explicitly enable strict mode:
+he.decode('foo&ampbar', {
+  'strict': true
+});
+// → Parse error
+```
+
+#### Overriding default `decode` options globally
+
+The global default settings for the `decode` function can be overridden by modifying the `he.decode.options` object. This saves you from passing in an `options` object for every call to `decode` if you want to use a non-default setting.
+
+```js
+// Read the global default setting:
+he.decode.options.isAttributeValue;
+// → `false` by default
+
+// Override the global default setting:
+he.decode.options.isAttributeValue = true;
+
+// Using the global default setting, which is now `true`:
+he.decode('foo&ampbar');
+// → 'foo&ampbar'
+```
+
+### `he.escape(text)`
+
+This function takes a string of text and escapes it for use in text contexts in XML or HTML documents. Only the following characters are escaped: `&`, `<`, `>`, `"`, `'`, and `` ` ``.
+
+```js
+he.escape('<img src=\'x\' onerror="prompt(1)">');
+// → '&lt;img src=&#x27;x&#x27; onerror=&quot;prompt(1)&quot;&gt;'
+```
+
+### `he.unescape(html, options)`
+
+`he.unescape` is an alias for `he.decode`. It takes a string of HTML and decodes any named and numerical character references in it.
+
+### Using the `he` binary
+
+To use the `he` binary in your shell, simply install _he_ globally using npm:
+
+```bash
+npm install -g he
+```
+
+After that you will be able to encode/decode HTML entities from the command line:
+
+```bash
+$ he --encode 'föo ♥ bår 𝌆 baz'
+f&#xF6;o &#x2665; b&#xE5;r &#x1D306; baz
+
+$ he --encode --use-named-refs 'föo ♥ bår 𝌆 baz'
+f&ouml;o &hearts; b&aring;r &#x1D306; baz
+
+$ he --decode 'f&ouml;o &hearts; b&aring;r &#x1D306; baz'
+föo ♥ bår 𝌆 baz
+```
+
+Read a local text file, encode it for use in an HTML text context, and save the result to a new file:
+
+```bash
+$ he --encode < foo.txt > foo-escaped.html
+```
+
+Or do the same with an online text file:
+
+```bash
+$ curl -sL "http://git.io/HnfEaw" | he --encode > escaped.html
+```
+
+Or, the opposite — read a local file containing a snippet of HTML in a text context, decode it back to plain text, and save the result to a new file:
+
+```bash
+$ he --decode < foo-escaped.html > foo.txt
+```
+
+Or do the same with an online HTML snippet:
+
+```bash
+$ curl -sL "http://git.io/HnfEaw" | he --decode > decoded.txt
+```
+
+See `he --help` for the full list of options.
+
+## Support
+
+_he_ has been tested in at least:
+
+* Chrome 27-50
+* Firefox 3-45
+* Safari 4-9
+* Opera 10-12, 15–37
+* IE 6–11
+* Edge
+* Narwhal 0.3.2
+* Node.js v0.10, v0.12, v4, v5
+* PhantomJS 1.9.0
+* Rhino 1.7RC4
+* RingoJS 0.8-0.11
+
+## Unit tests & code coverage
+
+After cloning this repository, run `npm install` to install the dependencies needed for he development and testing. You may want to install Istanbul _globally_ using `npm install istanbul -g`.
+
+Once that’s done, you can run the unit tests in Node using `npm test` or `node tests/tests.js`. To run the tests in Rhino, Ringo, Narwhal, and web browsers as well, use `grunt test`.
+
+To generate the code coverage report, use `grunt cover`.
+
+## Acknowledgements
+
+Thanks to [Simon Pieters](https://simon.html5.org/) ([@zcorpan](https://twitter.com/zcorpan)) for the many suggestions.
+
+## Author
+
+| [![twitter/mathias](https://gravatar.com/avatar/24e08a9ea84deb17ae121074d0f17125?s=70)](https://twitter.com/mathias "Follow @mathias on Twitter") |
+|---|
+| [Mathias Bynens](https://mathiasbynens.be/) |
+
+## License
+
+_he_ is available under the [MIT](https://mths.be/mit) license.

--- a/node_modules/inflight/README.md
+++ b/node_modules/inflight/README.md
@@ -1,0 +1,37 @@
+# inflight
+
+Add callbacks to requests in flight to avoid async duplication
+
+## USAGE
+
+```javascript
+var inflight = require('inflight')
+
+// some request that does some stuff
+function req(key, callback) {
+  // key is any random string.  like a url or filename or whatever.
+  //
+  // will return either a falsey value, indicating that the
+  // request for this key is already in flight, or a new callback
+  // which when called will call all callbacks passed to inflightk
+  // with the same key
+  callback = inflight(key, callback)
+
+  // If we got a falsey value back, then there's already a req going
+  if (!callback) return
+
+  // this is where you'd fetch the url or whatever
+  // callback is also once()-ified, so it can safely be assigned
+  // to multiple events etc.  First call wins.
+  setTimeout(function() {
+    callback(null, key)
+  }, 100)
+}
+
+// only assigns a single setTimeout
+// when it dings, all cbs get called
+req('foo', cb1)
+req('foo', cb2)
+req('foo', cb3)
+req('foo', cb4)
+```

--- a/node_modules/inherits/README.md
+++ b/node_modules/inherits/README.md
@@ -1,0 +1,42 @@
+Browser-friendly inheritance fully compatible with standard node.js
+[inherits](http://nodejs.org/api/util.html#util_util_inherits_constructor_superconstructor).
+
+This package exports standard `inherits` from node.js `util` module in
+node environment, but also provides alternative browser-friendly
+implementation through [browser
+field](https://gist.github.com/shtylman/4339901). Alternative
+implementation is a literal copy of standard one located in standalone
+module to avoid requiring of `util`. It also has a shim for old
+browsers with no `Object.create` support.
+
+While keeping you sure you are using standard `inherits`
+implementation in node.js environment, it allows bundlers such as
+[browserify](https://github.com/substack/node-browserify) to not
+include full `util` package to your client code if all you need is
+just `inherits` function. It worth, because browser shim for `util`
+package is large and `inherits` is often the single function you need
+from it.
+
+It's recommended to use this package instead of
+`require('util').inherits` for any code that has chances to be used
+not only in node.js but in browser too.
+
+## usage
+
+```js
+var inherits = require('inherits');
+// then use exactly as the standard one
+```
+
+## note on version ~1.0
+
+Version ~1.0 had completely different motivation and is not compatible
+neither with 2.0 nor with standard node.js `inherits`.
+
+If you are using version ~1.0 and planning to switch to ~2.0, be
+careful:
+
+* new version uses `super_` instead of `super` for referencing
+  superclass
+* new version overwrites current prototype while old one preserves any
+  existing fields on it

--- a/node_modules/is-buffer/README.md
+++ b/node_modules/is-buffer/README.md
@@ -1,0 +1,53 @@
+# is-buffer [![travis][travis-image]][travis-url] [![npm][npm-image]][npm-url] [![downloads][downloads-image]][downloads-url] [![javascript style guide][standard-image]][standard-url]
+
+[travis-image]: https://img.shields.io/travis/feross/is-buffer/master.svg
+[travis-url]: https://travis-ci.org/feross/is-buffer
+[npm-image]: https://img.shields.io/npm/v/is-buffer.svg
+[npm-url]: https://npmjs.org/package/is-buffer
+[downloads-image]: https://img.shields.io/npm/dm/is-buffer.svg
+[downloads-url]: https://npmjs.org/package/is-buffer
+[standard-image]: https://img.shields.io/badge/code_style-standard-brightgreen.svg
+[standard-url]: https://standardjs.com
+
+#### Determine if an object is a [`Buffer`](http://nodejs.org/api/buffer.html) (including the [browserify Buffer](https://github.com/feross/buffer))
+
+[![saucelabs][saucelabs-image]][saucelabs-url]
+
+[saucelabs-image]: https://saucelabs.com/browser-matrix/is-buffer.svg
+[saucelabs-url]: https://saucelabs.com/u/is-buffer
+
+## Why not use `Buffer.isBuffer`?
+
+This module lets you check if an object is a `Buffer` without using `Buffer.isBuffer` (which includes the whole [buffer](https://github.com/feross/buffer) module in [browserify](http://browserify.org/)).
+
+It's future-proof and works in node too!
+
+## install
+
+```bash
+npm install is-buffer
+```
+
+## usage
+
+```js
+var isBuffer = require('is-buffer')
+
+isBuffer(new Buffer(4)) // true
+
+isBuffer(undefined) // false
+isBuffer(null) // false
+isBuffer('') // false
+isBuffer(true) // false
+isBuffer(false) // false
+isBuffer(0) // false
+isBuffer(1) // false
+isBuffer(1.0) // false
+isBuffer('string') // false
+isBuffer({}) // false
+isBuffer(function foo () {}) // false
+```
+
+## license
+
+MIT. Copyright (C) [Feross Aboukhadijeh](http://feross.org).

--- a/node_modules/is-callable/README.md
+++ b/node_modules/is-callable/README.md
@@ -1,0 +1,59 @@
+# is-callable <sup>[![Version Badge][2]][1]</sup>
+
+[![Build Status][3]][4]
+[![dependency status][5]][6]
+[![dev dependency status][7]][8]
+[![License][license-image]][license-url]
+[![Downloads][downloads-image]][downloads-url]
+
+[![npm badge][11]][1]
+
+[![browser support][9]][10]
+
+Is this JS value callable? Works with Functions and GeneratorFunctions, despite ES6 @@toStringTag.
+
+## Example
+
+```js
+var isCallable = require('is-callable');
+var assert = require('assert');
+
+assert.notOk(isCallable(undefined));
+assert.notOk(isCallable(null));
+assert.notOk(isCallable(false));
+assert.notOk(isCallable(true));
+assert.notOk(isCallable([]));
+assert.notOk(isCallable({}));
+assert.notOk(isCallable(/a/g));
+assert.notOk(isCallable(new RegExp('a', 'g')));
+assert.notOk(isCallable(new Date()));
+assert.notOk(isCallable(42));
+assert.notOk(isCallable(NaN));
+assert.notOk(isCallable(Infinity));
+assert.notOk(isCallable(new Number(42)));
+assert.notOk(isCallable('foo'));
+assert.notOk(isCallable(Object('foo')));
+
+assert.ok(isCallable(function () {}));
+assert.ok(isCallable(function* () {}));
+assert.ok(isCallable(x => x * x));
+```
+
+## Tests
+Simply clone the repo, `npm install`, and run `npm test`
+
+[1]: https://npmjs.org/package/is-callable
+[2]: http://versionbadg.es/ljharb/is-callable.svg
+[3]: https://travis-ci.org/ljharb/is-callable.svg
+[4]: https://travis-ci.org/ljharb/is-callable
+[5]: https://david-dm.org/ljharb/is-callable.svg
+[6]: https://david-dm.org/ljharb/is-callable
+[7]: https://david-dm.org/ljharb/is-callable/dev-status.svg
+[8]: https://david-dm.org/ljharb/is-callable#info=devDependencies
+[9]: https://ci.testling.com/ljharb/is-callable.png
+[10]: https://ci.testling.com/ljharb/is-callable
+[11]: https://nodei.co/npm/is-callable.png?downloads=true&stars=true
+[license-image]: http://img.shields.io/npm/l/is-callable.svg
+[license-url]: LICENSE
+[downloads-image]: http://img.shields.io/npm/dm/is-callable.svg
+[downloads-url]: http://npm-stat.com/charts.html?package=is-callable

--- a/node_modules/is-date-object/README.md
+++ b/node_modules/is-date-object/README.md
@@ -1,0 +1,53 @@
+# is-date-object <sup>[![Version Badge][2]][1]</sup>
+
+[![Build Status][3]][4]
+[![dependency status][5]][6]
+[![dev dependency status][7]][8]
+[![License][license-image]][license-url]
+[![Downloads][downloads-image]][downloads-url]
+
+[![npm badge][11]][1]
+
+[![browser support][9]][10]
+
+Is this value a JS Date object? This module works cross-realm/iframe, and despite ES6 @@toStringTag.
+
+## Example
+
+```js
+var isDate = require('is-date-object');
+var assert = require('assert');
+
+assert.notOk(isDate(undefined));
+assert.notOk(isDate(null));
+assert.notOk(isDate(false));
+assert.notOk(isDate(true));
+assert.notOk(isDate(42));
+assert.notOk(isDate('foo'));
+assert.notOk(isDate(function () {}));
+assert.notOk(isDate([]));
+assert.notOk(isDate({}));
+assert.notOk(isDate(/a/g));
+assert.notOk(isDate(new RegExp('a', 'g')));
+
+assert.ok(isDate(new Date()));
+```
+
+## Tests
+Simply clone the repo, `npm install`, and run `npm test`
+
+[1]: https://npmjs.org/package/is-date-object
+[2]: http://versionbadg.es/ljharb/is-date-object.svg
+[3]: https://travis-ci.org/ljharb/is-date-object.svg
+[4]: https://travis-ci.org/ljharb/is-date-object
+[5]: https://david-dm.org/ljharb/is-date-object.svg
+[6]: https://david-dm.org/ljharb/is-date-object
+[7]: https://david-dm.org/ljharb/is-date-object/dev-status.svg
+[8]: https://david-dm.org/ljharb/is-date-object#info=devDependencies
+[9]: https://ci.testling.com/ljharb/is-date-object.png
+[10]: https://ci.testling.com/ljharb/is-date-object
+[11]: https://nodei.co/npm/is-date-object.png?downloads=true&stars=true
+[license-image]: http://img.shields.io/npm/l/is-date-object.svg
+[license-url]: LICENSE
+[downloads-image]: http://img.shields.io/npm/dm/is-date-object.svg
+[downloads-url]: http://npm-stat.com/charts.html?package=is-date-object

--- a/node_modules/is-regex/README.md
+++ b/node_modules/is-regex/README.md
@@ -1,0 +1,54 @@
+#is-regex <sup>[![Version Badge][2]][1]</sup>
+
+[![Build Status][3]][4]
+[![dependency status][5]][6]
+[![dev dependency status][7]][8]
+[![License][license-image]][license-url]
+[![Downloads][downloads-image]][downloads-url]
+
+[![npm badge][11]][1]
+
+[![browser support][9]][10]
+
+Is this value a JS regex?
+This module works cross-realm/iframe, and despite ES6 @@toStringTag.
+
+## Example
+
+```js
+var isRegex = require('is-regex');
+var assert = require('assert');
+
+assert.notOk(isRegex(undefined));
+assert.notOk(isRegex(null));
+assert.notOk(isRegex(false));
+assert.notOk(isRegex(true));
+assert.notOk(isRegex(42));
+assert.notOk(isRegex('foo'));
+assert.notOk(isRegex(function () {}));
+assert.notOk(isRegex([]));
+assert.notOk(isRegex({}));
+
+assert.ok(isRegex(/a/g));
+assert.ok(isRegex(new RegExp('a', 'g')));
+```
+
+## Tests
+Simply clone the repo, `npm install`, and run `npm test`
+
+[1]: https://npmjs.org/package/is-regex
+[2]: http://versionbadg.es/ljharb/is-regex.svg
+[3]: https://travis-ci.org/ljharb/is-regex.svg
+[4]: https://travis-ci.org/ljharb/is-regex
+[5]: https://david-dm.org/ljharb/is-regex.svg
+[6]: https://david-dm.org/ljharb/is-regex
+[7]: https://david-dm.org/ljharb/is-regex/dev-status.svg
+[8]: https://david-dm.org/ljharb/is-regex#info=devDependencies
+[9]: https://ci.testling.com/ljharb/is-regex.png
+[10]: https://ci.testling.com/ljharb/is-regex
+[11]: https://nodei.co/npm/is-regex.png?downloads=true&stars=true
+[license-image]: http://img.shields.io/npm/l/is-regex.svg
+[license-url]: LICENSE
+[downloads-image]: http://img.shields.io/npm/dm/is-regex.svg
+[downloads-url]: http://npm-stat.com/charts.html?package=is-regex
+

--- a/node_modules/is-symbol/README.md
+++ b/node_modules/is-symbol/README.md
@@ -1,0 +1,46 @@
+#is-symbol <sup>[![Version Badge][2]][1]</sup>
+
+[![Build Status][3]][4]
+[![dependency status][5]][6]
+[![dev dependency status][7]][8]
+[![License][license-image]][license-url]
+[![Downloads][downloads-image]][downloads-url]
+
+[![npm badge][11]][1]
+
+[![browser support][9]][10]
+
+Is this an ES6 Symbol value?
+
+## Example
+
+```js
+var isSymbol = require('is-symbol');
+assert(!isSymbol(function () {}));
+assert(!isSymbol(null));
+assert(!isSymbol(function* () { yield 42; return Infinity; });
+
+assert(isSymbol(Symbol.iterator));
+assert(isSymbol(Symbol('foo')));
+assert(isSymbol(Symbol.for('foo')));
+assert(isSymbol(Object(Symbol('foo'))));
+```
+
+## Tests
+Simply clone the repo, `npm install`, and run `npm test`
+
+[1]: https://npmjs.org/package/is-symbol
+[2]: http://versionbadg.es/ljharb/is-symbol.svg
+[3]: https://travis-ci.org/ljharb/is-symbol.svg
+[4]: https://travis-ci.org/ljharb/is-symbol
+[5]: https://david-dm.org/ljharb/is-symbol.svg
+[6]: https://david-dm.org/ljharb/is-symbol
+[7]: https://david-dm.org/ljharb/is-symbol/dev-status.svg
+[8]: https://david-dm.org/ljharb/is-symbol#info=devDependencies
+[9]: https://ci.testling.com/ljharb/is-symbol.png
+[10]: https://ci.testling.com/ljharb/is-symbol
+[11]: https://nodei.co/npm/is-symbol.png?downloads=true&stars=true
+[license-image]: http://img.shields.io/npm/l/is-symbol.svg
+[license-url]: LICENSE
+[downloads-image]: http://img.shields.io/npm/dm/is-symbol.svg
+[downloads-url]: http://npm-stat.com/charts.html?package=is-symbol

--- a/node_modules/isexe/README.md
+++ b/node_modules/isexe/README.md
@@ -1,0 +1,51 @@
+# isexe
+
+Minimal module to check if a file is executable, and a normal file.
+
+Uses `fs.stat` and tests against the `PATHEXT` environment variable on
+Windows.
+
+## USAGE
+
+```javascript
+var isexe = require('isexe')
+isexe('some-file-name', function (err, isExe) {
+  if (err) {
+    console.error('probably file does not exist or something', err)
+  } else if (isExe) {
+    console.error('this thing can be run')
+  } else {
+    console.error('cannot be run')
+  }
+})
+
+// same thing but synchronous, throws errors
+var isExe = isexe.sync('some-file-name')
+
+// treat errors as just "not executable"
+isexe('maybe-missing-file', { ignoreErrors: true }, callback)
+var isExe = isexe.sync('maybe-missing-file', { ignoreErrors: true })
+```
+
+## API
+
+### `isexe(path, [options], [callback])`
+
+Check if the path is executable.  If no callback provided, and a
+global `Promise` object is available, then a Promise will be returned.
+
+Will raise whatever errors may be raised by `fs.stat`, unless
+`options.ignoreErrors` is set to true.
+
+### `isexe.sync(path, [options])`
+
+Same as `isexe` but returns the value and throws any errors raised.
+
+### Options
+
+* `ignoreErrors` Treat all errors as "no, this is not executable", but
+  don't raise them.
+* `uid` Number to use as the user id
+* `gid` Number to use as the group id
+* `pathExt` List of path extensions to use instead of `PATHEXT`
+  environment variable on Windows.

--- a/node_modules/js-yaml/README.md
+++ b/node_modules/js-yaml/README.md
@@ -1,0 +1,314 @@
+JS-YAML - YAML 1.2 parser / writer for JavaScript
+=================================================
+
+[![Build Status](https://travis-ci.org/nodeca/js-yaml.svg?branch=master)](https://travis-ci.org/nodeca/js-yaml)
+[![NPM version](https://img.shields.io/npm/v/js-yaml.svg)](https://www.npmjs.org/package/js-yaml)
+
+__[Online Demo](http://nodeca.github.com/js-yaml/)__
+
+
+This is an implementation of [YAML](http://yaml.org/), a human-friendly data
+serialization language. Started as [PyYAML](http://pyyaml.org/) port, it was
+completely rewritten from scratch. Now it's very fast, and supports 1.2 spec.
+
+
+Installation
+------------
+
+### YAML module for node.js
+
+```
+npm install js-yaml
+```
+
+
+### CLI executable
+
+If you want to inspect your YAML files from CLI, install js-yaml globally:
+
+```
+npm install -g js-yaml
+```
+
+#### Usage
+
+```
+usage: js-yaml [-h] [-v] [-c] [-t] file
+
+Positional arguments:
+  file           File with YAML document(s)
+
+Optional arguments:
+  -h, --help     Show this help message and exit.
+  -v, --version  Show program's version number and exit.
+  -c, --compact  Display errors in compact mode
+  -t, --trace    Show stack trace on error
+```
+
+
+### Bundled YAML library for browsers
+
+``` html
+<!-- esprima required only for !!js/function -->
+<script src="esprima.js"></script>
+<script src="js-yaml.min.js"></script>
+<script type="text/javascript">
+var doc = jsyaml.load('greeting: hello\nname: world');
+</script>
+```
+
+Browser support was done mostly for the online demo. If you find any errors - feel
+free to send pull requests with fixes. Also note, that IE and other old browsers
+needs [es5-shims](https://github.com/kriskowal/es5-shim) to operate.
+
+Notes:
+
+1. We have no resources to support browserified version. Don't expect it to be
+   well tested. Don't expect fast fixes if something goes wrong there.
+2. `!!js/function` in browser bundle will not work by default. If you really need
+   it - load `esprima` parser first (via amd or directly).
+3. `!!bin` in browser will return `Array`, because browsers do not support
+   node.js `Buffer` and adding Buffer shims is completely useless on practice.
+
+
+API
+---
+
+Here we cover the most 'useful' methods. If you need advanced details (creating
+your own tags), see [wiki](https://github.com/nodeca/js-yaml/wiki) and
+[examples](https://github.com/nodeca/js-yaml/tree/master/examples) for more
+info.
+
+``` javascript
+yaml = require('js-yaml');
+fs   = require('fs');
+
+// Get document, or throw exception on error
+try {
+  var doc = yaml.safeLoad(fs.readFileSync('/home/ixti/example.yml', 'utf8'));
+  console.log(doc);
+} catch (e) {
+  console.log(e);
+}
+```
+
+
+### safeLoad (string [ , options ])
+
+**Recommended loading way.** Parses `string` as single YAML document. Returns a JavaScript
+object or throws `YAMLException` on error. By default, does not support regexps,
+functions and undefined. This method is safe for untrusted data.
+
+options:
+
+- `filename` _(default: null)_ - string to be used as a file path in
+  error/warning messages.
+- `onWarning` _(default: null)_ - function to call on warning messages.
+  Loader will call this function with an instance of `YAMLException` for each warning.
+- `schema` _(default: `DEFAULT_SAFE_SCHEMA`)_ - specifies a schema to use.
+  - `FAILSAFE_SCHEMA` - only strings, arrays and plain objects:
+    http://www.yaml.org/spec/1.2/spec.html#id2802346
+  - `JSON_SCHEMA` - all JSON-supported types:
+    http://www.yaml.org/spec/1.2/spec.html#id2803231
+  - `CORE_SCHEMA` - same as `JSON_SCHEMA`:
+    http://www.yaml.org/spec/1.2/spec.html#id2804923
+  - `DEFAULT_SAFE_SCHEMA` - all supported YAML types, without unsafe ones
+    (`!!js/undefined`, `!!js/regexp` and `!!js/function`):
+    http://yaml.org/type/
+  - `DEFAULT_FULL_SCHEMA` - all supported YAML types.
+- `json` _(default: false)_ - compatibility with JSON.parse behaviour. If true, then duplicate keys in a mapping will override values rather than throwing an error.
+
+NOTE: This function **does not** understand multi-document sources, it throws
+exception on those.
+
+NOTE: JS-YAML **does not** support schema-specific tag resolution restrictions.
+So, the JSON schema is not as strictly defined in the YAML specification.
+It allows numbers in any notation, use `Null` and `NULL` as `null`, etc.
+The core schema also has no such restrictions. It allows binary notation for integers.
+
+
+### load (string [ , options ])
+
+**Use with care with untrusted sources**. The same as `safeLoad()` but uses
+`DEFAULT_FULL_SCHEMA` by default - adds some JavaScript-specific types:
+`!!js/function`, `!!js/regexp` and `!!js/undefined`. For untrusted sources, you
+must additionally validate object structure to avoid injections:
+
+``` javascript
+var untrusted_code = '"toString": !<tag:yaml.org,2002:js/function> "function (){very_evil_thing();}"';
+
+// I'm just converting that string, what could possibly go wrong?
+require('js-yaml').load(untrusted_code) + ''
+```
+
+
+### safeLoadAll (string [, iterator] [, options ])
+
+Same as `safeLoad()`, but understands multi-document sources. Applies
+`iterator` to each document if specified, or returns array of documents.
+
+``` javascript
+var yaml = require('js-yaml');
+
+yaml.safeLoadAll(data, function (doc) {
+  console.log(doc);
+});
+```
+
+
+### loadAll (string [, iterator] [ , options ])
+
+Same as `safeLoadAll()` but uses `DEFAULT_FULL_SCHEMA` by default.
+
+
+### safeDump (object [ , options ])
+
+Serializes `object` as a YAML document. Uses `DEFAULT_SAFE_SCHEMA`, so it will
+throw an exception if you try to dump regexps or functions. However, you can
+disable exceptions by setting the `skipInvalid` option to `true`.
+
+options:
+
+- `indent` _(default: 2)_ - indentation width to use (in spaces).
+- `noArrayIndent` _(default: false)_ - when true, will not add an indentation level to array elements
+- `skipInvalid` _(default: false)_ - do not throw on invalid types (like function
+  in the safe schema) and skip pairs and single values with such types.
+- `flowLevel` (default: -1) - specifies level of nesting, when to switch from
+  block to flow style for collections. -1 means block style everwhere
+- `styles` - "tag" => "style" map. Each tag may have own set of styles.
+- `schema` _(default: `DEFAULT_SAFE_SCHEMA`)_ specifies a schema to use.
+- `sortKeys` _(default: `false`)_ - if `true`, sort keys when dumping YAML. If a
+  function, use the function to sort the keys.
+- `lineWidth` _(default: `80`)_ - set max line width.
+- `noRefs` _(default: `false`)_ - if `true`, don't convert duplicate objects into references
+- `noCompatMode` _(default: `false`)_ - if `true` don't try to be compatible with older
+  yaml versions. Currently: don't quote "yes", "no" and so on, as required for YAML 1.1
+- `condenseFlow` _(default: `false`)_ - if `true` flow sequences will be condensed, omitting the space between `a, b`. Eg. `'[a,b]'`, and omitting the space between `key: value` and quoting the key. Eg. `'{"a":b}'` Can be useful when using yaml for pretty URL query params as spaces are %-encoded.
+
+The following table show availlable styles (e.g. "canonical",
+"binary"...) available for each tag (.e.g. !!null, !!int ...). Yaml
+output is shown on the right side after `=>` (default setting) or `->`:
+
+``` none
+!!null
+  "canonical"   -> "~"
+  "lowercase"   => "null"
+  "uppercase"   -> "NULL"
+  "camelcase"   -> "Null"
+
+!!int
+  "binary"      -> "0b1", "0b101010", "0b1110001111010"
+  "octal"       -> "01", "052", "016172"
+  "decimal"     => "1", "42", "7290"
+  "hexadecimal" -> "0x1", "0x2A", "0x1C7A"
+
+!!bool
+  "lowercase"   => "true", "false"
+  "uppercase"   -> "TRUE", "FALSE"
+  "camelcase"   -> "True", "False"
+
+!!float
+  "lowercase"   => ".nan", '.inf'
+  "uppercase"   -> ".NAN", '.INF'
+  "camelcase"   -> ".NaN", '.Inf'
+```
+
+Example:
+
+``` javascript
+safeDump (object, {
+  'styles': {
+    '!!null': 'canonical' // dump null as ~
+  },
+  'sortKeys': true        // sort object keys
+});
+```
+
+### dump (object [ , options ])
+
+Same as `safeDump()` but without limits (uses `DEFAULT_FULL_SCHEMA` by default).
+
+
+Supported YAML types
+--------------------
+
+The list of standard YAML tags and corresponding JavaScipt types. See also
+[YAML tag discussion](http://pyyaml.org/wiki/YAMLTagDiscussion) and
+[YAML types repository](http://yaml.org/type/).
+
+```
+!!null ''                   # null
+!!bool 'yes'                # bool
+!!int '3...'                # number
+!!float '3.14...'           # number
+!!binary '...base64...'     # buffer
+!!timestamp 'YYYY-...'      # date
+!!omap [ ... ]              # array of key-value pairs
+!!pairs [ ... ]             # array or array pairs
+!!set { ... }               # array of objects with given keys and null values
+!!str '...'                 # string
+!!seq [ ... ]               # array
+!!map { ... }               # object
+```
+
+**JavaScript-specific tags**
+
+```
+!!js/regexp /pattern/gim            # RegExp
+!!js/undefined ''                   # Undefined
+!!js/function 'function () {...}'   # Function
+```
+
+Caveats
+-------
+
+Note, that you use arrays or objects as key in JS-YAML. JS does not allow objects
+or arrays as keys, and stringifies (by calling `toString()` method) them at the
+moment of adding them.
+
+``` yaml
+---
+? [ foo, bar ]
+: - baz
+? { foo: bar }
+: - baz
+  - baz
+```
+
+``` javascript
+{ "foo,bar": ["baz"], "[object Object]": ["baz", "baz"] }
+```
+
+Also, reading of properties on implicit block mapping keys is not supported yet.
+So, the following YAML document cannot be loaded.
+
+``` yaml
+&anchor foo:
+  foo: bar
+  *anchor: duplicate key
+  baz: bat
+  *anchor: duplicate key
+```
+
+
+Breaking changes in 2.x.x -> 3.x.x
+----------------------------------
+
+If you have not used __custom__ tags or loader classes and not loaded yaml
+files via `require()`, no changes are needed. Just upgrade the library.
+
+Otherwise, you should:
+
+1. Replace all occurrences of `require('xxxx.yml')` by `fs.readFileSync()` +
+  `yaml.safeLoad()`.
+2. rewrite your custom tags constructors and custom loader
+  classes, to conform the new API. See
+  [examples](https://github.com/nodeca/js-yaml/tree/master/examples) and
+  [wiki](https://github.com/nodeca/js-yaml/wiki) for details.
+
+
+License
+-------
+
+View the [LICENSE](https://github.com/nodeca/js-yaml/blob/master/LICENSE) file
+(MIT).

--- a/node_modules/lodash/README.md
+++ b/node_modules/lodash/README.md
@@ -1,0 +1,39 @@
+# lodash v4.17.11
+
+The [Lodash](https://lodash.com/) library exported as [Node.js](https://nodejs.org/) modules.
+
+## Installation
+
+Using npm:
+```shell
+$ npm i -g npm
+$ npm i --save lodash
+```
+
+In Node.js:
+```js
+// Load the full build.
+var _ = require('lodash');
+// Load the core build.
+var _ = require('lodash/core');
+// Load the FP build for immutable auto-curried iteratee-first data-last methods.
+var fp = require('lodash/fp');
+
+// Load method categories.
+var array = require('lodash/array');
+var object = require('lodash/fp/object');
+
+// Cherry-pick methods for smaller browserify/rollup/webpack bundles.
+var at = require('lodash/at');
+var curryN = require('lodash/fp/curryN');
+```
+
+See the [package source](https://github.com/lodash/lodash/tree/4.17.11-npm) for more details.
+
+**Note:**<br>
+Install [n_](https://www.npmjs.com/package/n_) for Lodash use in the Node.js < 6 REPL.
+
+## Support
+
+Tested in Chrome 68-69, Firefox 61-62, IE 11, Edge 17, Safari 10-11, Node.js 6-10, & PhantomJS 2.1.1.<br>
+Automated [browser](https://saucelabs.com/u/lodash) & [CI](https://travis-ci.org/lodash/lodash/) test runs are available.

--- a/node_modules/minimatch/README.md
+++ b/node_modules/minimatch/README.md
@@ -1,0 +1,209 @@
+# minimatch
+
+A minimal matching utility.
+
+[![Build Status](https://secure.travis-ci.org/isaacs/minimatch.svg)](http://travis-ci.org/isaacs/minimatch)
+
+
+This is the matching library used internally by npm.
+
+It works by converting glob expressions into JavaScript `RegExp`
+objects.
+
+## Usage
+
+```javascript
+var minimatch = require("minimatch")
+
+minimatch("bar.foo", "*.foo") // true!
+minimatch("bar.foo", "*.bar") // false!
+minimatch("bar.foo", "*.+(bar|foo)", { debug: true }) // true, and noisy!
+```
+
+## Features
+
+Supports these glob features:
+
+* Brace Expansion
+* Extended glob matching
+* "Globstar" `**` matching
+
+See:
+
+* `man sh`
+* `man bash`
+* `man 3 fnmatch`
+* `man 5 gitignore`
+
+## Minimatch Class
+
+Create a minimatch object by instantiating the `minimatch.Minimatch` class.
+
+```javascript
+var Minimatch = require("minimatch").Minimatch
+var mm = new Minimatch(pattern, options)
+```
+
+### Properties
+
+* `pattern` The original pattern the minimatch object represents.
+* `options` The options supplied to the constructor.
+* `set` A 2-dimensional array of regexp or string expressions.
+  Each row in the
+  array corresponds to a brace-expanded pattern.  Each item in the row
+  corresponds to a single path-part.  For example, the pattern
+  `{a,b/c}/d` would expand to a set of patterns like:
+
+        [ [ a, d ]
+        , [ b, c, d ] ]
+
+    If a portion of the pattern doesn't have any "magic" in it
+    (that is, it's something like `"foo"` rather than `fo*o?`), then it
+    will be left as a string rather than converted to a regular
+    expression.
+
+* `regexp` Created by the `makeRe` method.  A single regular expression
+  expressing the entire pattern.  This is useful in cases where you wish
+  to use the pattern somewhat like `fnmatch(3)` with `FNM_PATH` enabled.
+* `negate` True if the pattern is negated.
+* `comment` True if the pattern is a comment.
+* `empty` True if the pattern is `""`.
+
+### Methods
+
+* `makeRe` Generate the `regexp` member if necessary, and return it.
+  Will return `false` if the pattern is invalid.
+* `match(fname)` Return true if the filename matches the pattern, or
+  false otherwise.
+* `matchOne(fileArray, patternArray, partial)` Take a `/`-split
+  filename, and match it against a single row in the `regExpSet`.  This
+  method is mainly for internal use, but is exposed so that it can be
+  used by a glob-walker that needs to avoid excessive filesystem calls.
+
+All other methods are internal, and will be called as necessary.
+
+### minimatch(path, pattern, options)
+
+Main export.  Tests a path against the pattern using the options.
+
+```javascript
+var isJS = minimatch(file, "*.js", { matchBase: true })
+```
+
+### minimatch.filter(pattern, options)
+
+Returns a function that tests its
+supplied argument, suitable for use with `Array.filter`.  Example:
+
+```javascript
+var javascripts = fileList.filter(minimatch.filter("*.js", {matchBase: true}))
+```
+
+### minimatch.match(list, pattern, options)
+
+Match against the list of
+files, in the style of fnmatch or glob.  If nothing is matched, and
+options.nonull is set, then return a list containing the pattern itself.
+
+```javascript
+var javascripts = minimatch.match(fileList, "*.js", {matchBase: true}))
+```
+
+### minimatch.makeRe(pattern, options)
+
+Make a regular expression object from the pattern.
+
+## Options
+
+All options are `false` by default.
+
+### debug
+
+Dump a ton of stuff to stderr.
+
+### nobrace
+
+Do not expand `{a,b}` and `{1..3}` brace sets.
+
+### noglobstar
+
+Disable `**` matching against multiple folder names.
+
+### dot
+
+Allow patterns to match filenames starting with a period, even if
+the pattern does not explicitly have a period in that spot.
+
+Note that by default, `a/**/b` will **not** match `a/.d/b`, unless `dot`
+is set.
+
+### noext
+
+Disable "extglob" style patterns like `+(a|b)`.
+
+### nocase
+
+Perform a case-insensitive match.
+
+### nonull
+
+When a match is not found by `minimatch.match`, return a list containing
+the pattern itself if this option is set.  When not set, an empty list
+is returned if there are no matches.
+
+### matchBase
+
+If set, then patterns without slashes will be matched
+against the basename of the path if it contains slashes.  For example,
+`a?b` would match the path `/xyz/123/acb`, but not `/xyz/acb/123`.
+
+### nocomment
+
+Suppress the behavior of treating `#` at the start of a pattern as a
+comment.
+
+### nonegate
+
+Suppress the behavior of treating a leading `!` character as negation.
+
+### flipNegate
+
+Returns from negate expressions the same as if they were not negated.
+(Ie, true on a hit, false on a miss.)
+
+
+## Comparisons to other fnmatch/glob implementations
+
+While strict compliance with the existing standards is a worthwhile
+goal, some discrepancies exist between minimatch and other
+implementations, and are intentional.
+
+If the pattern starts with a `!` character, then it is negated.  Set the
+`nonegate` flag to suppress this behavior, and treat leading `!`
+characters normally.  This is perhaps relevant if you wish to start the
+pattern with a negative extglob pattern like `!(a|B)`.  Multiple `!`
+characters at the start of a pattern will negate the pattern multiple
+times.
+
+If a pattern starts with `#`, then it is treated as a comment, and
+will not match anything.  Use `\#` to match a literal `#` at the
+start of a line, or set the `nocomment` flag to suppress this behavior.
+
+The double-star character `**` is supported by default, unless the
+`noglobstar` flag is set.  This is supported in the manner of bsdglob
+and bash 4.1, where `**` only has special significance if it is the only
+thing in a path part.  That is, `a/**/b` will match `a/x/y/b`, but
+`a/**b` will not.
+
+If an escaped pattern has no matches, and the `nonull` flag is set,
+then minimatch.match returns the pattern as-provided, rather than
+interpreting the character escapes.  For example,
+`minimatch.match([], "\\*a\\?")` will return `"\\*a\\?"` rather than
+`"*a?"`.  This is akin to setting the `nullglob` option in bash, except
+that it does not resolve escaped pattern characters.
+
+If brace expansion is not disabled, then it is performed before any
+other interpretation of the glob pattern.  Thus, a pattern like
+`+(a|{b),c)}`, which would not be valid in bash or zsh, is expanded
+**first** into the set of `+(a|b)` and `+(a|c)`, and those patterns are
+checked for validity.  Since those two are valid, matching proceeds.

--- a/node_modules/mocha/README.md
+++ b/node_modules/mocha/README.md
@@ -1,0 +1,105 @@
+<p align="center">
+  <img src="https://cldup.com/xFVFxOioAU.svg" alt="Mocha test framework"/>
+</p>
+
+<p align="center">:coffee: Simple, flexible, fun JavaScript test framework for Node.js & The Browser :coffee:</p>
+
+<p align="center"><a href="http://travis-ci.org/mochajs/mocha"><img src="https://api.travis-ci.org/mochajs/mocha.svg?branch=master" alt="Build Status"></a>  <a href="https://coveralls.io/github/mochajs/mocha"><img src="https://coveralls.io/repos/github/mochajs/mocha/badge.svg" alt="Coverage Status"></a>  <a href="https://app.fossa.io/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fmochajs%2Fmocha?ref=badge_shield"><img src="https://app.fossa.io/api/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fmochajs%2Fmocha.svg?type=shield" alt="FOSSA Status"></a>  <a href="https://gitter.im/mochajs/mocha?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge"><img src="https://badges.gitter.im/Join%20Chat.svg" alt="Gitter"></a>  <a href="https://github.com/mochajs/mocha#backers"><img src="https://opencollective.com/mochajs/backers/badge.svg" alt="OpenCollective"></a>  <a href="https://github.com/mochajs/mocha#sponsors"><img src="https://opencollective.com/mochajs/sponsors/badge.svg" alt="OpenCollective"></a>
+</p>
+
+<p align="center"><br><img alt="Mocha Browser Support h/t SauceLabs" src="https://saucelabs.com/browser-matrix/mochajs.svg" width="354"></p>
+
+## Links
+
+- **[Documentation](https://mochajs.org/)**
+- **[Release Notes / History / Changes](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md)**
+- [Code of Conduct](https://github.com/mochajs/mocha/blob/master/.github/CODE_OF_CONDUCT.md)
+- [Contributing](https://github.com/mochajs/mocha/blob/master/.github/CONTRIBUTING.md)
+- [Gitter Chatroom](https://gitter.im/mochajs/mocha) (ask questions here!)
+- [Google Group](https://groups.google.com/group/mochajs)
+- [Issue Tracker](https://github.com/mochajs/mocha/issues)
+
+## Backers
+
+[Become a backer](https://opencollective.com/mochajs#backer) and show your support to our open source project.
+
+[![MochaJS Backer](https://opencollective.com/mochajs/backer/0/avatar)](https://opencollective.com/mochajs/backer/0/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/backer/1/avatar)](https://opencollective.com/mochajs/backer/1/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/backer/2/avatar)](https://opencollective.com/mochajs/backer/2/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/backer/3/avatar)](https://opencollective.com/mochajs/backer/3/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/backer/4/avatar)](https://opencollective.com/mochajs/backer/4/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/backer/5/avatar)](https://opencollective.com/mochajs/backer/5/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/backer/6/avatar)](https://opencollective.com/mochajs/backer/6/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/backer/7/avatar)](https://opencollective.com/mochajs/backer/7/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/backer/8/avatar)](https://opencollective.com/mochajs/backer/8/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/backer/9/avatar)](https://opencollective.com/mochajs/backer/9/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/backer/10/avatar)](https://opencollective.com/mochajs/backer/10/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/backer/11/avatar)](https://opencollective.com/mochajs/backer/11/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/backer/12/avatar)](https://opencollective.com/mochajs/backer/12/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/backer/13/avatar)](https://opencollective.com/mochajs/backer/13/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/backer/14/avatar)](https://opencollective.com/mochajs/backer/14/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/backer/15/avatar)](https://opencollective.com/mochajs/backer/15/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/backer/16/avatar)](https://opencollective.com/mochajs/backer/16/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/backer/17/avatar)](https://opencollective.com/mochajs/backer/17/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/backer/18/avatar)](https://opencollective.com/mochajs/backer/18/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/backer/19/avatar)](https://opencollective.com/mochajs/backer/19/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/backer/20/avatar)](https://opencollective.com/mochajs/backer/20/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/backer/21/avatar)](https://opencollective.com/mochajs/backer/21/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/backer/22/avatar)](https://opencollective.com/mochajs/backer/22/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/backer/23/avatar)](https://opencollective.com/mochajs/backer/23/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/backer/24/avatar)](https://opencollective.com/mochajs/backer/24/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/backer/25/avatar)](https://opencollective.com/mochajs/backer/25/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/backer/26/avatar)](https://opencollective.com/mochajs/backer/26/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/backer/27/avatar)](https://opencollective.com/mochajs/backer/27/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/backer/28/avatar)](https://opencollective.com/mochajs/backer/28/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/backer/29/avatar)](https://opencollective.com/mochajs/backer/29/website)
+
+## Sponsors
+
+Does your company use Mocha?  Ask your manager or marketing team if your company would be interested in supporting our project.  Support will allow the maintainers to dedicate more time for maintenance and new features for everyone.  Also, your company's logo will show [on GitHub](https://github.com/mochajs/mocha#readme) and on [our site](https://mochajs.org) - who doesn't want a little extra exposure?  [Here's the info](https://opencollective.com/mochajs#sponsor).
+
+[![MochaJS Backer](https://opencollective.com/mochajs/sponsor/0/avatar)](https://opencollective.com/mochajs/sponsor/0/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/sponsor/1/avatar)](https://opencollective.com/mochajs/sponsor/1/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/sponsor/2/avatar)](https://opencollective.com/mochajs/sponsor/2/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/sponsor/3/avatar)](https://opencollective.com/mochajs/sponsor/3/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/sponsor/4/avatar)](https://opencollective.com/mochajs/sponsor/4/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/sponsor/5/avatar)](https://opencollective.com/mochajs/sponsor/5/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/sponsor/6/avatar)](https://opencollective.com/mochajs/sponsor/6/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/sponsor/7/avatar)](https://opencollective.com/mochajs/sponsor/7/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/sponsor/8/avatar)](https://opencollective.com/mochajs/sponsor/8/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/sponsor/9/avatar)](https://opencollective.com/mochajs/sponsor/9/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/sponsor/10/avatar)](https://opencollective.com/mochajs/sponsor/10/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/sponsor/11/avatar)](https://opencollective.com/mochajs/sponsor/11/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/sponsor/12/avatar)](https://opencollective.com/mochajs/sponsor/12/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/sponsor/13/avatar)](https://opencollective.com/mochajs/sponsor/13/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/sponsor/14/avatar)](https://opencollective.com/mochajs/sponsor/14/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/sponsor/15/avatar)](https://opencollective.com/mochajs/sponsor/15/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/sponsor/16/avatar)](https://opencollective.com/mochajs/sponsor/16/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/sponsor/17/avatar)](https://opencollective.com/mochajs/sponsor/17/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/sponsor/18/avatar)](https://opencollective.com/mochajs/sponsor/18/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/sponsor/19/avatar)](https://opencollective.com/mochajs/sponsor/19/website)
+
+## Development
+
+You might want to know that:
+
+- Mocha is the *most-depended-upon* module on npm (source: [libraries.io](https://libraries.io/search?order=desc&platforms=NPM&sort=dependents_count)), and
+- Mocha is an *independent* open-source project, maintained exclusively by volunteers.
+
+You might want to help:
+
+- New to contributing to Mocha?  Check out this list of [good first issues](https://github.com/mochajs/mocha/issues?q=is%3Aissue+is%3Aopen+label%3Agood-first-issue)
+- Mocha could use a hand with [these issues](https://github.com/mochajs/mocha/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
+- The [maintainer's handbook](https://github.com/mochajs/mocha/blob/master/MAINTAINERS.md) explains how things get done
+
+Finally, come [chat with the maintainers](https://gitter.im/mochajs/contributors) on Gitter if you want to help with:
+
+- Triaging issues, answering questions
+- Review, merging, and closing pull requests
+- Other project-maintenance-y things
+
+## License
+
+[MIT](LICENSE)
+
+[![FOSSA Status](https://app.fossa.io/api/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fmochajs%2Fmocha.svg?type=large)](https://app.fossa.io/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fmochajs%2Fmocha?ref=badge_large)

--- a/node_modules/nice-try/README.md
+++ b/node_modules/nice-try/README.md
@@ -1,0 +1,32 @@
+# nice-try
+
+[![Travis Build Status](https://travis-ci.org/electerious/nice-try.svg?branch=master)](https://travis-ci.org/electerious/nice-try) [![AppVeyor Status](https://ci.appveyor.com/api/projects/status/8tqb09wrwci3xf8l?svg=true)](https://ci.appveyor.com/project/electerious/nice-try) [![Coverage Status](https://coveralls.io/repos/github/electerious/nice-try/badge.svg?branch=master)](https://coveralls.io/github/electerious/nice-try?branch=master) [![Dependencies](https://david-dm.org/electerious/nice-try.svg)](https://david-dm.org/electerious/nice-try#info=dependencies) [![Greenkeeper badge](https://badges.greenkeeper.io/electerious/nice-try.svg)](https://greenkeeper.io/)
+
+A function that tries to execute a function and discards any error that occurs.
+
+## Install
+
+```
+npm install nice-try
+```
+
+## Usage
+
+```js
+const niceTry = require('nice-try')
+
+niceTry(() => JSON.parse('true')) // true
+niceTry(() => JSON.parse('truee')) // undefined
+niceTry() // undefined
+niceTry(true) // undefined
+```
+
+## API
+
+### Parameters
+
+- `fn` `{Function}` Function that might or might not throw an error.
+
+### Returns
+
+- `{?*}` Return-value of the function when no error occurred.

--- a/node_modules/node-environment-flags/README.md
+++ b/node_modules/node-environment-flags/README.md
@@ -1,0 +1,59 @@
+# node-environment-flags
+
+> Polyfill/shim for `process.allowedNodeEnvironmentFlags`
+
+[![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
+
+**node-environment-flags** is a *rough* polyfill and shim for [process.allowedNodeEnvironmentFlags](https://nodejs.org/api/process.html#process_process_allowednodeenvironmentflags), which was introduced in Node.js v10.10.0.
+
+## Table of Contents
+
+- [Install](#install)
+- [Usage](#usage)
+- [Maintainers](#maintainers)
+- [Contribute](#contribute)
+- [License](#license)
+
+## Install
+
+*Requires Node.js v6.0.0 or newer.*
+
+```shell
+$ npm i node-environment-flags
+```
+
+## Usage
+
+If the current Node.js version is v10.10.0 or newer, the native implementation will be provided instead.
+
+### As Polyfill (Recommended)
+
+```js
+const nodeEnvironmentFlags = require('node-environment-flags');
+
+nodeEnvironmentFlags.has('--require'); // true
+```
+
+### As Shim
+
+```js
+require('node-environment-flags/shim')();
+
+process.allowedNodeEnvironmentFlags.has('--require'); // true
+```
+
+## Notes
+
+- This module approximates what `process.allowedNodeEnvironmentFlags` provides in versions of Node.js prior to v10.10.0.  Since `process.allowedNodeEnvironmentFlags` is based on [`NODE_OPTIONS`](https://nodejs.org/api/cli.html#cli_node_options_options) (introduced in v8.0.0), the set of supported flags for versions older than v8.0.0 is *highly theoretical*.
+- Version ranges are matched using [semver](https://npm.im/semver).
+- This module is granular to the *minor* Node.js version number; *patch* version numbers are not considered.
+- Results for unmaintained (odd) versions of Node.js are based on data for the most recent LTS version; e.g., running this module against Node.js v7.10.0 will yield the same results as would v6.14.0.
+- Prior art: @ljharb's [util.promisify](https://npm.im/util.promisify)
+
+## Maintainers
+
+[@boneskull](https://github.com/boneskull)
+
+## License
+
+Copyright © 2018 Christopher Hiller.  Licensed Apache-2.0.

--- a/node_modules/object-keys/README.md
+++ b/node_modules/object-keys/README.md
@@ -1,0 +1,76 @@
+#object-keys <sup>[![Version Badge][npm-version-svg]][package-url]</sup>
+
+[![Build Status][travis-svg]][travis-url]
+[![dependency status][deps-svg]][deps-url]
+[![dev dependency status][dev-deps-svg]][dev-deps-url]
+[![License][license-image]][license-url]
+[![Downloads][downloads-image]][downloads-url]
+
+[![npm badge][npm-badge-png]][package-url]
+
+[![browser support][testling-svg]][testling-url]
+
+An Object.keys shim. Invoke its "shim" method to shim Object.keys if it is unavailable.
+
+Most common usage:
+```js
+var keys = Object.keys || require('object-keys');
+```
+
+## Example
+
+```js
+var keys = require('object-keys');
+var assert = require('assert');
+var obj = {
+	a: true,
+	b: true,
+	c: true
+};
+
+assert.deepEqual(keys(obj), ['a', 'b', 'c']);
+```
+
+```js
+var keys = require('object-keys');
+var assert = require('assert');
+/* when Object.keys is not present */
+delete Object.keys;
+var shimmedKeys = keys.shim();
+assert.equal(shimmedKeys, keys);
+assert.deepEqual(Object.keys(obj), keys(obj));
+```
+
+```js
+var keys = require('object-keys');
+var assert = require('assert');
+/* when Object.keys is present */
+var shimmedKeys = keys.shim();
+assert.equal(shimmedKeys, Object.keys);
+assert.deepEqual(Object.keys(obj), keys(obj));
+```
+
+## Source
+Implementation taken directly from [es5-shim][es5-shim-url], with modifications, including from [lodash][lodash-url].
+
+## Tests
+Simply clone the repo, `npm install`, and run `npm test`
+
+[package-url]: https://npmjs.org/package/object-keys
+[npm-version-svg]: http://versionbadg.es/ljharb/object-keys.svg
+[travis-svg]: https://travis-ci.org/ljharb/object-keys.svg
+[travis-url]: https://travis-ci.org/ljharb/object-keys
+[deps-svg]: https://david-dm.org/ljharb/object-keys.svg
+[deps-url]: https://david-dm.org/ljharb/object-keys
+[dev-deps-svg]: https://david-dm.org/ljharb/object-keys/dev-status.svg
+[dev-deps-url]: https://david-dm.org/ljharb/object-keys#info=devDependencies
+[testling-svg]: https://ci.testling.com/ljharb/object-keys.png
+[testling-url]: https://ci.testling.com/ljharb/object-keys
+[es5-shim-url]: https://github.com/es-shims/es5-shim/blob/master/es5-shim.js#L542-589
+[lodash-url]: https://github.com/lodash/lodash
+[npm-badge-png]: https://nodei.co/npm/object-keys.png?downloads=true&stars=true
+[license-image]: http://img.shields.io/npm/l/object-keys.svg
+[license-url]: LICENSE
+[downloads-image]: http://img.shields.io/npm/dm/object-keys.svg
+[downloads-url]: http://npm-stat.com/charts.html?package=object-keys
+

--- a/node_modules/object.assign/README.md
+++ b/node_modules/object.assign/README.md
@@ -1,0 +1,135 @@
+#object.assign <sup>[![Version Badge][npm-version-svg]][npm-url]</sup>
+
+[![Build Status][travis-svg]][travis-url]
+[![dependency status][deps-svg]][deps-url]
+[![dev dependency status][dev-deps-svg]][dev-deps-url]
+[![License][license-image]][license-url]
+[![Downloads][downloads-image]][downloads-url]
+
+[![npm badge][npm-badge-png]][npm-url]
+
+[![browser support][testling-png]][testling-url]
+
+An Object.assign shim. Invoke its "shim" method to shim Object.assign if it is unavailable.
+
+This package implements the [es-shim API](https://github.com/es-shims/api) interface. It works in an ES3-supported environment and complies with the [spec](http://www.ecma-international.org/ecma-262/6.0/#sec-object.assign). In an ES6 environment, it will also work properly with `Symbol`s.
+
+Takes a minimum of 2 arguments: `target` and `source`.
+Takes a variable sized list of source arguments - at least 1, as many as you want.
+Throws a TypeError if the `target` argument is `null` or `undefined`.
+
+Most common usage:
+```js
+var assign = require('object.assign').getPolyfill(); // returns native method if compliant
+	/* or */
+var assign = require('object.assign/polyfill')(); // returns native method if compliant
+```
+
+## Example
+
+```js
+var assert = require('assert');
+
+// Multiple sources!
+var target = { a: true };
+var source1 = { b: true };
+var source2 = { c: true };
+var sourceN = { n: true };
+
+var expected = {
+	a: true,
+	b: true,
+	c: true,
+	n: true
+};
+
+assign(target, source1, source2, sourceN);
+assert.deepEqual(target, expected); // AWESOME!
+```
+
+```js
+var target = {
+	a: true,
+	b: true,
+	c: true
+};
+var source1 = {
+	c: false,
+	d: false
+};
+var sourceN = {
+	e: false
+};
+
+var assigned = assign(target, source1, sourceN);
+assert.equal(target, assigned); // returns the target object
+assert.deepEqual(assigned, {
+	a: true,
+	b: true,
+	c: false,
+	d: false,
+	e: false
+});
+```
+
+```js
+/* when Object.assign is not present */
+delete Object.assign;
+var shimmedAssign = require('object.assign').shim();
+	/* or */
+var shimmedAssign = require('object.assign/shim')();
+
+assert.equal(shimmedAssign, assign);
+
+var target = {
+	a: true,
+	b: true,
+	c: true
+};
+var source = {
+	c: false,
+	d: false,
+	e: false
+};
+
+var assigned = assign(target, source);
+assert.deepEqual(Object.assign(target, source), assign(target, source));
+```
+
+```js
+/* when Object.assign is present */
+var shimmedAssign = require('object.assign').shim();
+assert.equal(shimmedAssign, Object.assign);
+
+var target = {
+	a: true,
+	b: true,
+	c: true
+};
+var source = {
+	c: false,
+	d: false,
+	e: false
+};
+
+assert.deepEqual(Object.assign(target, source), assign(target, source));
+```
+
+## Tests
+Simply clone the repo, `npm install`, and run `npm test`
+
+[npm-url]: https://npmjs.org/package/object.assign
+[npm-version-svg]: http://versionbadg.es/ljharb/object.assign.svg
+[travis-svg]: https://travis-ci.org/ljharb/object.assign.svg
+[travis-url]: https://travis-ci.org/ljharb/object.assign
+[deps-svg]: https://david-dm.org/ljharb/object.assign.svg?theme=shields.io
+[deps-url]: https://david-dm.org/ljharb/object.assign
+[dev-deps-svg]: https://david-dm.org/ljharb/object.assign/dev-status.svg?theme=shields.io
+[dev-deps-url]: https://david-dm.org/ljharb/object.assign#info=devDependencies
+[testling-png]: https://ci.testling.com/ljharb/object.assign.png
+[testling-url]: https://ci.testling.com/ljharb/object.assign
+[npm-badge-png]: https://nodei.co/npm/object.assign.png?downloads=true&stars=true
+[license-image]: http://img.shields.io/npm/l/object.assign.svg
+[license-url]: LICENSE
+[downloads-image]: http://img.shields.io/npm/dm/object.assign.svg
+[downloads-url]: http://npm-stat.com/charts.html?package=object.assign

--- a/node_modules/object.getownpropertydescriptors/README.md
+++ b/node_modules/object.getownpropertydescriptors/README.md
@@ -1,0 +1,99 @@
+#object.getownpropertydescriptors <sup>[![Version Badge][npm-version-svg]][package-url]</sup>
+
+[![Build Status][travis-svg]][travis-url]
+[![dependency status][deps-svg]][deps-url]
+[![dev dependency status][dev-deps-svg]][dev-deps-url]
+[![License][license-image]][license-url]
+[![Downloads][downloads-image]][downloads-url]
+
+[![npm badge][npm-badge-png]][package-url]
+
+[![browser support][testling-svg]][testling-url]
+
+An ES2017 spec-compliant shim for `Object.getOwnPropertyDescriptors` that works in ES5.
+Invoke its "shim" method to shim `Object.getOwnPropertyDescriptors` if it is unavailable, and if `Object.getOwnPropertyDescriptor` is available.
+
+This package implements the [es-shim API](https://github.com/es-shims/api) interface. It works in an ES3-supported environment and complies with the [spec](https://github.com/tc39/ecma262/pull/582).
+
+## Example
+
+```js
+var getDescriptors = require('object.getownpropertydescriptors');
+var assert = require('assert');
+var obj = { normal: Infinity };
+var enumDescriptor = {
+	enumerable: false,
+	writable: false,
+	configurable: true,
+	value: true
+};
+var writableDescriptor = {
+	enumerable: true,
+	writable: true,
+	configurable: true,
+	value: 42
+};
+var symbol = Symbol();
+var symDescriptor = {
+	enumerable: true,
+	writable: true,
+	configurable: false,
+	value: [symbol]
+};
+
+Object.defineProperty(obj, 'enumerable', enumDescriptor);
+Object.defineProperty(obj, 'writable', writableDescriptor);
+Object.defineProperty(obj, 'symbol', symDescriptor);
+
+var descriptors = getDescriptors(obj);
+
+assert.deepEqual(descriptors, {
+	normal: {
+		enumerable: true,
+		writable: true,
+		configurable: true,
+		value: Infinity
+	},
+	enumerable: enumDescriptor,
+	writable: writableDescriptor,
+	symbol: symDescriptor
+});
+```
+
+```js
+var getDescriptors = require('object.getownpropertydescriptors');
+var assert = require('assert');
+/* when Object.getOwnPropertyDescriptors is not present */
+delete Object.getOwnPropertyDescriptors;
+var shimmedDescriptors = getDescriptors.shim();
+assert.equal(shimmedDescriptors, getDescriptors);
+assert.deepEqual(shimmedDescriptors(obj), getDescriptors(obj));
+```
+
+```js
+var getDescriptors = require('object.getownpropertydescriptors');
+var assert = require('assert');
+/* when Object.getOwnPropertyDescriptors is present */
+var shimmedDescriptors = getDescriptors.shim();
+assert.notEqual(shimmedDescriptors, getDescriptors);
+assert.deepEqual(shimmedDescriptors(obj), getDescriptors(obj));
+```
+
+## Tests
+Simply clone the repo, `npm install`, and run `npm test`
+
+[package-url]: https://npmjs.org/package/object.getownpropertydescriptors
+[npm-version-svg]: http://versionbadg.es/ljharb/object.getownpropertydescriptors.svg
+[travis-svg]: https://travis-ci.org/ljharb/object.getownpropertydescriptors.svg
+[travis-url]: https://travis-ci.org/ljharb/object.getownpropertydescriptors
+[deps-svg]: https://david-dm.org/ljharb/object.getownpropertydescriptors.svg
+[deps-url]: https://david-dm.org/ljharb/object.getownpropertydescriptors
+[dev-deps-svg]: https://david-dm.org/ljharb/object.getownpropertydescriptors/dev-status.svg
+[dev-deps-url]: https://david-dm.org/ljharb/object.getownpropertydescriptors#info=devDependencies
+[testling-svg]: https://ci.testling.com/ljharb/object.getownpropertydescriptors.png
+[testling-url]: https://ci.testling.com/ljharb/object.getownpropertydescriptors
+[npm-badge-png]: https://nodei.co/npm/object.getownpropertydescriptors.png?downloads=true&stars=true
+[license-image]: http://img.shields.io/npm/l/object.getownpropertydescriptors.svg
+[license-url]: LICENSE
+[downloads-image]: http://img.shields.io/npm/dm/object.getownpropertydescriptors.svg
+[downloads-url]: http://npm-stat.com/charts.html?package=object.getownpropertydescriptors

--- a/node_modules/once/README.md
+++ b/node_modules/once/README.md
@@ -1,0 +1,79 @@
+# once
+
+Only call a function once.
+
+## usage
+
+```javascript
+var once = require('once')
+
+function load (file, cb) {
+  cb = once(cb)
+  loader.load('file')
+  loader.once('load', cb)
+  loader.once('error', cb)
+}
+```
+
+Or add to the Function.prototype in a responsible way:
+
+```javascript
+// only has to be done once
+require('once').proto()
+
+function load (file, cb) {
+  cb = cb.once()
+  loader.load('file')
+  loader.once('load', cb)
+  loader.once('error', cb)
+}
+```
+
+Ironically, the prototype feature makes this module twice as
+complicated as necessary.
+
+To check whether you function has been called, use `fn.called`. Once the
+function is called for the first time the return value of the original
+function is saved in `fn.value` and subsequent calls will continue to
+return this value.
+
+```javascript
+var once = require('once')
+
+function load (cb) {
+  cb = once(cb)
+  var stream = createStream()
+  stream.once('data', cb)
+  stream.once('end', function () {
+    if (!cb.called) cb(new Error('not found'))
+  })
+}
+```
+
+## `once.strict(func)`
+
+Throw an error if the function is called twice.
+
+Some functions are expected to be called only once. Using `once` for them would
+potentially hide logical errors.
+
+In the example below, the `greet` function has to call the callback only once:
+
+```javascript
+function greet (name, cb) {
+  // return is missing from the if statement
+  // when no name is passed, the callback is called twice
+  if (!name) cb('Hello anonymous')
+  cb('Hello ' + name)
+}
+
+function log (msg) {
+  console.log(msg)
+}
+
+// this will print 'Hello anonymous' but the logical error will be missed
+greet(null, once(msg))
+
+// once.strict will print 'Hello anonymous' and throw an error when the callback will be called the second time
+greet(null, once.strict(msg))
+```

--- a/node_modules/pump/README.md
+++ b/node_modules/pump/README.md
@@ -1,0 +1,65 @@
+# pump
+
+pump is a small node module that pipes streams together and destroys all of them if one of them closes.
+
+```
+npm install pump
+```
+
+[![build status](http://img.shields.io/travis/mafintosh/pump.svg?style=flat)](http://travis-ci.org/mafintosh/pump)
+
+## What problem does it solve?
+
+When using standard `source.pipe(dest)` source will _not_ be destroyed if dest emits close or an error.
+You are also not able to provide a callback to tell when then pipe has finished.
+
+pump does these two things for you
+
+## Usage
+
+Simply pass the streams you want to pipe together to pump and add an optional callback
+
+``` js
+var pump = require('pump')
+var fs = require('fs')
+
+var source = fs.createReadStream('/dev/random')
+var dest = fs.createWriteStream('/dev/null')
+
+pump(source, dest, function(err) {
+  console.log('pipe finished', err)
+})
+
+setTimeout(function() {
+  dest.destroy() // when dest is closed pump will destroy source
+}, 1000)
+```
+
+You can use pump to pipe more than two streams together as well
+
+``` js
+var transform = someTransformStream()
+
+pump(source, transform, anotherTransform, dest, function(err) {
+  console.log('pipe finished', err)
+})
+```
+
+If `source`, `transform`, `anotherTransform` or `dest` closes all of them will be destroyed.
+
+Similarly to `stream.pipe()`, `pump()` returns the last stream passed in, so you can do:
+
+```
+return pump(s1, s2) // returns s2
+```
+
+If you want to return a stream that combines *both* s1 and s2 to a single stream use
+[pumpify](https://github.com/mafintosh/pumpify) instead.
+
+## License
+
+MIT
+
+## Related
+
+`pump` is part of the [mississippi stream utility collection](https://github.com/maxogden/mississippi) which includes more useful stream modules similar to this one.

--- a/node_modules/require-main-filename/README.md
+++ b/node_modules/require-main-filename/README.md
@@ -1,0 +1,26 @@
+# require-main-filename
+
+[![Build Status](https://travis-ci.org/yargs/require-main-filename.png)](https://travis-ci.org/yargs/require-main-filename)
+[![Coverage Status](https://coveralls.io/repos/yargs/require-main-filename/badge.svg?branch=master)](https://coveralls.io/r/yargs/require-main-filename?branch=master)
+[![NPM version](https://img.shields.io/npm/v/require-main-filename.svg)](https://www.npmjs.com/package/require-main-filename)
+
+`require.main.filename` is great for figuring out the entry
+point for the current application. This can be combined with a module like
+[pkg-conf](https://www.npmjs.com/package/pkg-conf) to, _as if by magic_, load
+top-level configuration.
+
+Unfortunately, `require.main.filename` sometimes fails when an application is
+executed with an alternative process manager, e.g., [iisnode](https://github.com/tjanczuk/iisnode).
+
+`require-main-filename` is a shim that addresses this problem.
+
+## Usage
+
+```js
+var main = require('require-main-filename')()
+// use main as an alternative to require.main.filename.
+```
+
+## License
+
+ISC

--- a/node_modules/semver/README.md
+++ b/node_modules/semver/README.md
@@ -1,0 +1,411 @@
+semver(1) -- The semantic versioner for npm
+===========================================
+
+## Install
+
+```bash
+npm install --save semver
+````
+
+## Usage
+
+As a node module:
+
+```js
+const semver = require('semver')
+
+semver.valid('1.2.3') // '1.2.3'
+semver.valid('a.b.c') // null
+semver.clean('  =v1.2.3   ') // '1.2.3'
+semver.satisfies('1.2.3', '1.x || >=2.5.0 || 5.0.0 - 7.2.3') // true
+semver.gt('1.2.3', '9.8.7') // false
+semver.lt('1.2.3', '9.8.7') // true
+semver.minVersion('>=1.0.0') // '1.0.0'
+semver.valid(semver.coerce('v2')) // '2.0.0'
+semver.valid(semver.coerce('42.6.7.9.3-alpha')) // '42.6.7'
+```
+
+As a command-line utility:
+
+```
+$ semver -h
+
+A JavaScript implementation of the https://semver.org/ specification
+Copyright Isaac Z. Schlueter
+
+Usage: semver [options] <version> [<version> [...]]
+Prints valid versions sorted by SemVer precedence
+
+Options:
+-r --range <range>
+        Print versions that match the specified range.
+
+-i --increment [<level>]
+        Increment a version by the specified level.  Level can
+        be one of: major, minor, patch, premajor, preminor,
+        prepatch, or prerelease.  Default level is 'patch'.
+        Only one version may be specified.
+
+--preid <identifier>
+        Identifier to be used to prefix premajor, preminor,
+        prepatch or prerelease version increments.
+
+-l --loose
+        Interpret versions and ranges loosely
+
+-p --include-prerelease
+        Always include prerelease versions in range matching
+
+-c --coerce
+        Coerce a string into SemVer if possible
+        (does not imply --loose)
+
+Program exits successfully if any valid version satisfies
+all supplied ranges, and prints all satisfying versions.
+
+If no satisfying versions are found, then exits failure.
+
+Versions are printed in ascending order, so supplying
+multiple versions to the utility will just sort them.
+```
+
+## Versions
+
+A "version" is described by the `v2.0.0` specification found at
+<https://semver.org/>.
+
+A leading `"="` or `"v"` character is stripped off and ignored.
+
+## Ranges
+
+A `version range` is a set of `comparators` which specify versions
+that satisfy the range.
+
+A `comparator` is composed of an `operator` and a `version`.  The set
+of primitive `operators` is:
+
+* `<` Less than
+* `<=` Less than or equal to
+* `>` Greater than
+* `>=` Greater than or equal to
+* `=` Equal.  If no operator is specified, then equality is assumed,
+  so this operator is optional, but MAY be included.
+
+For example, the comparator `>=1.2.7` would match the versions
+`1.2.7`, `1.2.8`, `2.5.3`, and `1.3.9`, but not the versions `1.2.6`
+or `1.1.0`.
+
+Comparators can be joined by whitespace to form a `comparator set`,
+which is satisfied by the **intersection** of all of the comparators
+it includes.
+
+A range is composed of one or more comparator sets, joined by `||`.  A
+version matches a range if and only if every comparator in at least
+one of the `||`-separated comparator sets is satisfied by the version.
+
+For example, the range `>=1.2.7 <1.3.0` would match the versions
+`1.2.7`, `1.2.8`, and `1.2.99`, but not the versions `1.2.6`, `1.3.0`,
+or `1.1.0`.
+
+The range `1.2.7 || >=1.2.9 <2.0.0` would match the versions `1.2.7`,
+`1.2.9`, and `1.4.6`, but not the versions `1.2.8` or `2.0.0`.
+
+### Prerelease Tags
+
+If a version has a prerelease tag (for example, `1.2.3-alpha.3`) then
+it will only be allowed to satisfy comparator sets if at least one
+comparator with the same `[major, minor, patch]` tuple also has a
+prerelease tag.
+
+For example, the range `>1.2.3-alpha.3` would be allowed to match the
+version `1.2.3-alpha.7`, but it would *not* be satisfied by
+`3.4.5-alpha.9`, even though `3.4.5-alpha.9` is technically "greater
+than" `1.2.3-alpha.3` according to the SemVer sort rules.  The version
+range only accepts prerelease tags on the `1.2.3` version.  The
+version `3.4.5` *would* satisfy the range, because it does not have a
+prerelease flag, and `3.4.5` is greater than `1.2.3-alpha.7`.
+
+The purpose for this behavior is twofold.  First, prerelease versions
+frequently are updated very quickly, and contain many breaking changes
+that are (by the author's design) not yet fit for public consumption.
+Therefore, by default, they are excluded from range matching
+semantics.
+
+Second, a user who has opted into using a prerelease version has
+clearly indicated the intent to use *that specific* set of
+alpha/beta/rc versions.  By including a prerelease tag in the range,
+the user is indicating that they are aware of the risk.  However, it
+is still not appropriate to assume that they have opted into taking a
+similar risk on the *next* set of prerelease versions.
+
+Note that this behavior can be suppressed (treating all prerelease
+versions as if they were normal versions, for the purpose of range
+matching) by setting the `includePrerelease` flag on the options
+object to any
+[functions](https://github.com/npm/node-semver#functions) that do
+range matching.
+
+#### Prerelease Identifiers
+
+The method `.inc` takes an additional `identifier` string argument that
+will append the value of the string as a prerelease identifier:
+
+```javascript
+semver.inc('1.2.3', 'prerelease', 'beta')
+// '1.2.4-beta.0'
+```
+
+command-line example:
+
+```bash
+$ semver 1.2.3 -i prerelease --preid beta
+1.2.4-beta.0
+```
+
+Which then can be used to increment further:
+
+```bash
+$ semver 1.2.4-beta.0 -i prerelease
+1.2.4-beta.1
+```
+
+### Advanced Range Syntax
+
+Advanced range syntax desugars to primitive comparators in
+deterministic ways.
+
+Advanced ranges may be combined in the same way as primitive
+comparators using white space or `||`.
+
+#### Hyphen Ranges `X.Y.Z - A.B.C`
+
+Specifies an inclusive set.
+
+* `1.2.3 - 2.3.4` := `>=1.2.3 <=2.3.4`
+
+If a partial version is provided as the first version in the inclusive
+range, then the missing pieces are replaced with zeroes.
+
+* `1.2 - 2.3.4` := `>=1.2.0 <=2.3.4`
+
+If a partial version is provided as the second version in the
+inclusive range, then all versions that start with the supplied parts
+of the tuple are accepted, but nothing that would be greater than the
+provided tuple parts.
+
+* `1.2.3 - 2.3` := `>=1.2.3 <2.4.0`
+* `1.2.3 - 2` := `>=1.2.3 <3.0.0`
+
+#### X-Ranges `1.2.x` `1.X` `1.2.*` `*`
+
+Any of `X`, `x`, or `*` may be used to "stand in" for one of the
+numeric values in the `[major, minor, patch]` tuple.
+
+* `*` := `>=0.0.0` (Any version satisfies)
+* `1.x` := `>=1.0.0 <2.0.0` (Matching major version)
+* `1.2.x` := `>=1.2.0 <1.3.0` (Matching major and minor versions)
+
+A partial version range is treated as an X-Range, so the special
+character is in fact optional.
+
+* `""` (empty string) := `*` := `>=0.0.0`
+* `1` := `1.x.x` := `>=1.0.0 <2.0.0`
+* `1.2` := `1.2.x` := `>=1.2.0 <1.3.0`
+
+#### Tilde Ranges `~1.2.3` `~1.2` `~1`
+
+Allows patch-level changes if a minor version is specified on the
+comparator.  Allows minor-level changes if not.
+
+* `~1.2.3` := `>=1.2.3 <1.(2+1).0` := `>=1.2.3 <1.3.0`
+* `~1.2` := `>=1.2.0 <1.(2+1).0` := `>=1.2.0 <1.3.0` (Same as `1.2.x`)
+* `~1` := `>=1.0.0 <(1+1).0.0` := `>=1.0.0 <2.0.0` (Same as `1.x`)
+* `~0.2.3` := `>=0.2.3 <0.(2+1).0` := `>=0.2.3 <0.3.0`
+* `~0.2` := `>=0.2.0 <0.(2+1).0` := `>=0.2.0 <0.3.0` (Same as `0.2.x`)
+* `~0` := `>=0.0.0 <(0+1).0.0` := `>=0.0.0 <1.0.0` (Same as `0.x`)
+* `~1.2.3-beta.2` := `>=1.2.3-beta.2 <1.3.0` Note that prereleases in
+  the `1.2.3` version will be allowed, if they are greater than or
+  equal to `beta.2`.  So, `1.2.3-beta.4` would be allowed, but
+  `1.2.4-beta.2` would not, because it is a prerelease of a
+  different `[major, minor, patch]` tuple.
+
+#### Caret Ranges `^1.2.3` `^0.2.5` `^0.0.4`
+
+Allows changes that do not modify the left-most non-zero digit in the
+`[major, minor, patch]` tuple.  In other words, this allows patch and
+minor updates for versions `1.0.0` and above, patch updates for
+versions `0.X >=0.1.0`, and *no* updates for versions `0.0.X`.
+
+Many authors treat a `0.x` version as if the `x` were the major
+"breaking-change" indicator.
+
+Caret ranges are ideal when an author may make breaking changes
+between `0.2.4` and `0.3.0` releases, which is a common practice.
+However, it presumes that there will *not* be breaking changes between
+`0.2.4` and `0.2.5`.  It allows for changes that are presumed to be
+additive (but non-breaking), according to commonly observed practices.
+
+* `^1.2.3` := `>=1.2.3 <2.0.0`
+* `^0.2.3` := `>=0.2.3 <0.3.0`
+* `^0.0.3` := `>=0.0.3 <0.0.4`
+* `^1.2.3-beta.2` := `>=1.2.3-beta.2 <2.0.0` Note that prereleases in
+  the `1.2.3` version will be allowed, if they are greater than or
+  equal to `beta.2`.  So, `1.2.3-beta.4` would be allowed, but
+  `1.2.4-beta.2` would not, because it is a prerelease of a
+  different `[major, minor, patch]` tuple.
+* `^0.0.3-beta` := `>=0.0.3-beta <0.0.4`  Note that prereleases in the
+  `0.0.3` version *only* will be allowed, if they are greater than or
+  equal to `beta`.  So, `0.0.3-pr.2` would be allowed.
+
+When parsing caret ranges, a missing `patch` value desugars to the
+number `0`, but will allow flexibility within that value, even if the
+major and minor versions are both `0`.
+
+* `^1.2.x` := `>=1.2.0 <2.0.0`
+* `^0.0.x` := `>=0.0.0 <0.1.0`
+* `^0.0` := `>=0.0.0 <0.1.0`
+
+A missing `minor` and `patch` values will desugar to zero, but also
+allow flexibility within those values, even if the major version is
+zero.
+
+* `^1.x` := `>=1.0.0 <2.0.0`
+* `^0.x` := `>=0.0.0 <1.0.0`
+
+### Range Grammar
+
+Putting all this together, here is a Backus-Naur grammar for ranges,
+for the benefit of parser authors:
+
+```bnf
+range-set  ::= range ( logical-or range ) *
+logical-or ::= ( ' ' ) * '||' ( ' ' ) *
+range      ::= hyphen | simple ( ' ' simple ) * | ''
+hyphen     ::= partial ' - ' partial
+simple     ::= primitive | partial | tilde | caret
+primitive  ::= ( '<' | '>' | '>=' | '<=' | '=' ) partial
+partial    ::= xr ( '.' xr ( '.' xr qualifier ? )? )?
+xr         ::= 'x' | 'X' | '*' | nr
+nr         ::= '0' | ['1'-'9'] ( ['0'-'9'] ) *
+tilde      ::= '~' partial
+caret      ::= '^' partial
+qualifier  ::= ( '-' pre )? ( '+' build )?
+pre        ::= parts
+build      ::= parts
+parts      ::= part ( '.' part ) *
+part       ::= nr | [-0-9A-Za-z]+
+```
+
+## Functions
+
+All methods and classes take a final `options` object argument.  All
+options in this object are `false` by default.  The options supported
+are:
+
+- `loose`  Be more forgiving about not-quite-valid semver strings.
+  (Any resulting output will always be 100% strict compliant, of
+  course.)  For backwards compatibility reasons, if the `options`
+  argument is a boolean value instead of an object, it is interpreted
+  to be the `loose` param.
+- `includePrerelease`  Set to suppress the [default
+  behavior](https://github.com/npm/node-semver#prerelease-tags) of
+  excluding prerelease tagged versions from ranges unless they are
+  explicitly opted into.
+
+Strict-mode Comparators and Ranges will be strict about the SemVer
+strings that they parse.
+
+* `valid(v)`: Return the parsed version, or null if it's not valid.
+* `inc(v, release)`: Return the version incremented by the release
+  type (`major`,   `premajor`, `minor`, `preminor`, `patch`,
+  `prepatch`, or `prerelease`), or null if it's not valid
+  * `premajor` in one call will bump the version up to the next major
+    version and down to a prerelease of that major version.
+    `preminor`, and `prepatch` work the same way.
+  * If called from a non-prerelease version, the `prerelease` will work the
+    same as `prepatch`. It increments the patch version, then makes a
+    prerelease. If the input version is already a prerelease it simply
+    increments it.
+* `prerelease(v)`: Returns an array of prerelease components, or null
+  if none exist. Example: `prerelease('1.2.3-alpha.1') -> ['alpha', 1]`
+* `major(v)`: Return the major version number.
+* `minor(v)`: Return the minor version number.
+* `patch(v)`: Return the patch version number.
+* `intersects(r1, r2, loose)`: Return true if the two supplied ranges
+  or comparators intersect.
+* `parse(v)`: Attempt to parse a string as a semantic version, returning either
+  a `SemVer` object or `null`.
+
+### Comparison
+
+* `gt(v1, v2)`: `v1 > v2`
+* `gte(v1, v2)`: `v1 >= v2`
+* `lt(v1, v2)`: `v1 < v2`
+* `lte(v1, v2)`: `v1 <= v2`
+* `eq(v1, v2)`: `v1 == v2` This is true if they're logically equivalent,
+  even if they're not the exact same string.  You already know how to
+  compare strings.
+* `neq(v1, v2)`: `v1 != v2` The opposite of `eq`.
+* `cmp(v1, comparator, v2)`: Pass in a comparison string, and it'll call
+  the corresponding function above.  `"==="` and `"!=="` do simple
+  string comparison, but are included for completeness.  Throws if an
+  invalid comparison string is provided.
+* `compare(v1, v2)`: Return `0` if `v1 == v2`, or `1` if `v1` is greater, or `-1` if
+  `v2` is greater.  Sorts in ascending order if passed to `Array.sort()`.
+* `rcompare(v1, v2)`: The reverse of compare.  Sorts an array of versions
+  in descending order when passed to `Array.sort()`.
+* `diff(v1, v2)`: Returns difference between two versions by the release type
+  (`major`, `premajor`, `minor`, `preminor`, `patch`, `prepatch`, or `prerelease`),
+  or null if the versions are the same.
+
+### Comparators
+
+* `intersects(comparator)`: Return true if the comparators intersect
+
+### Ranges
+
+* `validRange(range)`: Return the valid range or null if it's not valid
+* `satisfies(version, range)`: Return true if the version satisfies the
+  range.
+* `maxSatisfying(versions, range)`: Return the highest version in the list
+  that satisfies the range, or `null` if none of them do.
+* `minSatisfying(versions, range)`: Return the lowest version in the list
+  that satisfies the range, or `null` if none of them do.
+* `minVersion(range)`: Return the lowest version that can possibly match
+  the given range.
+* `gtr(version, range)`: Return `true` if version is greater than all the
+  versions possible in the range.
+* `ltr(version, range)`: Return `true` if version is less than all the
+  versions possible in the range.
+* `outside(version, range, hilo)`: Return true if the version is outside
+  the bounds of the range in either the high or low direction.  The
+  `hilo` argument must be either the string `'>'` or `'<'`.  (This is
+  the function called by `gtr` and `ltr`.)
+* `intersects(range)`: Return true if any of the ranges comparators intersect
+
+Note that, since ranges may be non-contiguous, a version might not be
+greater than a range, less than a range, *or* satisfy a range!  For
+example, the range `1.2 <1.2.9 || >2.0.0` would have a hole from `1.2.9`
+until `2.0.0`, so the version `1.2.10` would not be greater than the
+range (because `2.0.1` satisfies, which is higher), nor less than the
+range (since `1.2.8` satisfies, which is lower), and it also does not
+satisfy the range.
+
+If you want to know if a version satisfies or does not satisfy a
+range, use the `satisfies(version, range)` function.
+
+### Coercion
+
+* `coerce(version)`: Coerces a string to semver if possible
+
+This aims to provide a very forgiving translation of a non-semver
+string to semver. It looks for the first digit in a string, and
+consumes all remaining characters which satisfy at least a partial semver
+(e.g., `1`, `1.2`, `1.2.3`) up to the max permitted length (256 characters).
+Longer versions are simply truncated (`4.6.3.9.2-alpha2` becomes `4.6.3`).
+All surrounding text is simply ignored (`v3.4 replaces v3.3.1` becomes `3.4.0`).
+Only text which lacks digits will fail coercion (`version one` is not valid).
+The maximum  length for any semver component considered for coercion is 16 characters;
+longer components will be ignored (`10000000000000000.4.7.4` becomes `4.7.4`).
+The maximum value for any semver component is `Integer.MAX_SAFE_INTEGER || (2**53 - 1)`;
+higher value components are invalid (`9999999999999999.4.7.4` is likely invalid).

--- a/node_modules/set-blocking/README.md
+++ b/node_modules/set-blocking/README.md
@@ -1,0 +1,31 @@
+# set-blocking
+
+[![Build Status](https://travis-ci.org/yargs/set-blocking.svg)](https://travis-ci.org/yargs/set-blocking)
+[![NPM version](https://img.shields.io/npm/v/set-blocking.svg)](https://www.npmjs.com/package/set-blocking)
+[![Coverage Status](https://coveralls.io/repos/yargs/set-blocking/badge.svg?branch=)](https://coveralls.io/r/yargs/set-blocking?branch=master)
+[![Standard Version](https://img.shields.io/badge/release-standard%20version-brightgreen.svg)](https://github.com/conventional-changelog/standard-version)
+
+set blocking `stdio` and `stderr` ensuring that terminal output does not truncate.
+
+```js
+const setBlocking = require('set-blocking')
+setBlocking(true)
+console.log(someLargeStringToOutput)
+```
+
+## Historical Context/Word of Warning
+
+This was created as a shim to address the bug discussed in [node #6456](https://github.com/nodejs/node/issues/6456). This bug crops up on
+newer versions of Node.js (`0.12+`), truncating terminal output.
+
+You should be mindful of the side-effects caused by using `set-blocking`:
+
+* if your module sets blocking to `true`, it will effect other modules
+  consuming your library. In [yargs](https://github.com/yargs/yargs/blob/master/yargs.js#L653) we only call
+  `setBlocking(true)` once we already know we are about to call `process.exit(code)`.
+* this patch will not apply to subprocesses spawned with `isTTY = true`, this is
+  the [default `spawn()` behavior](https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options).
+
+## License
+
+ISC

--- a/node_modules/signal-exit/README.md
+++ b/node_modules/signal-exit/README.md
@@ -1,0 +1,40 @@
+# signal-exit
+
+[![Build Status](https://travis-ci.org/tapjs/signal-exit.png)](https://travis-ci.org/tapjs/signal-exit)
+[![Coverage](https://coveralls.io/repos/tapjs/signal-exit/badge.svg?branch=master)](https://coveralls.io/r/tapjs/signal-exit?branch=master)
+[![NPM version](https://img.shields.io/npm/v/signal-exit.svg)](https://www.npmjs.com/package/signal-exit)
+[![Windows Tests](https://img.shields.io/appveyor/ci/bcoe/signal-exit/master.svg?label=Windows%20Tests)](https://ci.appveyor.com/project/bcoe/signal-exit)
+[![Standard Version](https://img.shields.io/badge/release-standard%20version-brightgreen.svg)](https://github.com/conventional-changelog/standard-version)
+
+When you want to fire an event no matter how a process exits:
+
+* reaching the end of execution.
+* explicitly having `process.exit(code)` called.
+* having `process.kill(pid, sig)` called.
+* receiving a fatal signal from outside the process
+
+Use `signal-exit`.
+
+```js
+var onExit = require('signal-exit')
+
+onExit(function (code, signal) {
+  console.log('process exited!')
+})
+```
+
+## API
+
+`var remove = onExit(function (code, signal) {}, options)`
+
+The return value of the function is a function that will remove the
+handler.
+
+Note that the function *only* fires for signals if the signal would
+cause the proces to exit.  That is, there are no other listeners, and
+it is a fatal signal.
+
+## Options
+
+* `alwaysLast`: Run this handler after any other signal or exit
+  handlers.  This causes `process.emit` to be monkeypatched.

--- a/node_modules/sprintf-js/README.md
+++ b/node_modules/sprintf-js/README.md
@@ -1,0 +1,88 @@
+# sprintf.js
+**sprintf.js** is a complete open source JavaScript sprintf implementation for the *browser* and *node.js*.
+
+Its prototype is simple:
+
+    string sprintf(string format , [mixed arg1 [, mixed arg2 [ ,...]]])
+
+The placeholders in the format string are marked by `%` and are followed by one or more of these elements, in this order:
+
+* An optional number followed by a `$` sign that selects which argument index to use for the value. If not specified, arguments will be placed in the same order as the placeholders in the input string.
+* An optional `+` sign that forces to preceed the result with a plus or minus sign on numeric values. By default, only the `-` sign is used on negative numbers.
+* An optional padding specifier that says what character to use for padding (if specified). Possible values are `0` or any other character precedeed by a `'` (single quote). The default is to pad with *spaces*.
+* An optional `-` sign, that causes sprintf to left-align the result of this placeholder. The default is to right-align the result.
+* An optional number, that says how many characters the result should have. If the value to be returned is shorter than this number, the result will be padded. When used with the `j` (JSON) type specifier, the padding length specifies the tab size used for indentation.
+* An optional precision modifier, consisting of a `.` (dot) followed by a number, that says how many digits should be displayed for floating point numbers. When used with the `g` type specifier, it specifies the number of significant digits. When used on a string, it causes the result to be truncated.
+* A type specifier that can be any of:
+    * `%` — yields a literal `%` character
+    * `b` — yields an integer as a binary number
+    * `c` — yields an integer as the character with that ASCII value
+    * `d` or `i` — yields an integer as a signed decimal number
+    * `e` — yields a float using scientific notation
+    * `u` — yields an integer as an unsigned decimal number
+    * `f` — yields a float as is; see notes on precision above
+    * `g` — yields a float as is; see notes on precision above
+    * `o` — yields an integer as an octal number
+    * `s` — yields a string as is
+    * `x` — yields an integer as a hexadecimal number (lower-case)
+    * `X` — yields an integer as a hexadecimal number (upper-case)
+    * `j` — yields a JavaScript object or array as a JSON encoded string
+
+## JavaScript `vsprintf`
+`vsprintf` is the same as `sprintf` except that it accepts an array of arguments, rather than a variable number of arguments:
+
+    vsprintf("The first 4 letters of the english alphabet are: %s, %s, %s and %s", ["a", "b", "c", "d"])
+
+## Argument swapping
+You can also swap the arguments. That is, the order of the placeholders doesn't have to match the order of the arguments. You can do that by simply indicating in the format string which arguments the placeholders refer to:
+
+    sprintf("%2$s %3$s a %1$s", "cracker", "Polly", "wants")
+And, of course, you can repeat the placeholders without having to increase the number of arguments.
+
+## Named arguments
+Format strings may contain replacement fields rather than positional placeholders. Instead of referring to a certain argument, you can now refer to a certain key within an object. Replacement fields are surrounded by rounded parentheses - `(` and `)` - and begin with a keyword that refers to a key:
+
+    var user = {
+        name: "Dolly"
+    }
+    sprintf("Hello %(name)s", user) // Hello Dolly
+Keywords in replacement fields can be optionally followed by any number of keywords or indexes:
+
+    var users = [
+        {name: "Dolly"},
+        {name: "Molly"},
+        {name: "Polly"}
+    ]
+    sprintf("Hello %(users[0].name)s, %(users[1].name)s and %(users[2].name)s", {users: users}) // Hello Dolly, Molly and Polly
+Note: mixing positional and named placeholders is not (yet) supported
+
+## Computed values
+You can pass in a function as a dynamic value and it will be invoked (with no arguments) in order to compute the value on-the-fly.
+
+    sprintf("Current timestamp: %d", Date.now) // Current timestamp: 1398005382890
+    sprintf("Current date and time: %s", function() { return new Date().toString() })
+
+# AngularJS
+You can now use `sprintf` and `vsprintf` (also aliased as `fmt` and `vfmt` respectively) in your AngularJS projects. See `demo/`.
+
+# Installation
+
+## Via Bower
+
+    bower install sprintf
+
+## Or as a node.js module
+
+    npm install sprintf-js
+
+### Usage
+
+    var sprintf = require("sprintf-js").sprintf,
+        vsprintf = require("sprintf-js").vsprintf
+
+    sprintf("%2$s %3$s a %1$s", "cracker", "Polly", "wants")
+    vsprintf("The first 4 letters of the english alphabet are: %s, %s, %s and %s", ["a", "b", "c", "d"])
+
+# License
+
+**sprintf.js** is licensed under the terms of the 3-clause BSD license.

--- a/node_modules/which-module/README.md
+++ b/node_modules/which-module/README.md
@@ -1,0 +1,55 @@
+# which-module
+
+> Find the module object for something that was require()d
+
+[![Build Status](https://travis-ci.org/nexdrew/which-module.svg?branch=master)](https://travis-ci.org/nexdrew/which-module)
+[![Coverage Status](https://coveralls.io/repos/github/nexdrew/which-module/badge.svg?branch=master)](https://coveralls.io/github/nexdrew/which-module?branch=master)
+[![Standard Version](https://img.shields.io/badge/release-standard%20version-brightgreen.svg)](https://github.com/conventional-changelog/standard-version)
+
+Find the `module` object in `require.cache` for something that was `require()`d
+or `import`ed - essentially a reverse `require()` lookup.
+
+Useful for libs that want to e.g. lookup a filename for a module or submodule
+that it did not `require()` itself.
+
+## Install and Usage
+
+```
+npm install --save which-module
+```
+
+```js
+const whichModule = require('which-module')
+
+console.log(whichModule(require('something')))
+// Module {
+//   id: '/path/to/project/node_modules/something/index.js',
+//   exports: [Function],
+//   parent: ...,
+//   filename: '/path/to/project/node_modules/something/index.js',
+//   loaded: true,
+//   children: [],
+//   paths: [ '/path/to/project/node_modules/something/node_modules',
+//            '/path/to/project/node_modules',
+//            '/path/to/node_modules',
+//            '/path/node_modules',
+//            '/node_modules' ] }
+```
+
+## API
+
+### `whichModule(exported)`
+
+Return the [`module` object](https://nodejs.org/api/modules.html#modules_the_module_object),
+if any, that represents the given argument in the `require.cache`.
+
+`exported` can be anything that was previously `require()`d or `import`ed as a
+module, submodule, or dependency - which means `exported` is identical to the
+`module.exports` returned by this method.
+
+If `exported` did not come from the `exports` of a `module` in `require.cache`,
+then this method returns `null`.
+
+## License
+
+ISC © Contributors

--- a/node_modules/which/README.md
+++ b/node_modules/which/README.md
@@ -1,0 +1,51 @@
+# which
+
+Like the unix `which` utility.
+
+Finds the first instance of a specified executable in the PATH
+environment variable.  Does not cache the results, so `hash -r` is not
+needed when the PATH changes.
+
+## USAGE
+
+```javascript
+var which = require('which')
+
+// async usage
+which('node', function (er, resolvedPath) {
+  // er is returned if no "node" is found on the PATH
+  // if it is found, then the absolute path to the exec is returned
+})
+
+// sync usage
+// throws if not found
+var resolved = which.sync('node')
+
+// if nothrow option is used, returns null if not found
+resolved = which.sync('node', {nothrow: true})
+
+// Pass options to override the PATH and PATHEXT environment vars.
+which('node', { path: someOtherPath }, function (er, resolved) {
+  if (er)
+    throw er
+  console.log('found at %j', resolved)
+})
+```
+
+## CLI USAGE
+
+Same as the BSD `which(1)` binary.
+
+```
+usage: which [-as] program ...
+```
+
+## OPTIONS
+
+You may pass an options object as the second argument.
+
+- `path`: Use instead of the `PATH` environment variable.
+- `pathExt`: Use instead of the `PATHEXT` environment variable.
+- `all`: Return all matches, instead of just the first one.  Note that
+  this means the function returns an array of strings instead of a
+  single string.

--- a/node_modules/wide-align/README.md
+++ b/node_modules/wide-align/README.md
@@ -1,0 +1,47 @@
+wide-align
+----------
+
+A wide-character aware text alignment function for use in terminals / on the
+console.
+
+### Usage
+
+```
+var align = require('wide-align')
+
+// Note that if you view this on a unicode console, all of the slashes are
+// aligned. This is because on a console, all narrow characters are
+// an en wide and all wide characters are an em. In browsers, this isn't
+// held to and wide characters like "古" can be less than two narrow
+// characters even with a fixed width font.
+
+console.log(align.center('abc', 10))     // '   abc    '
+console.log(align.center('古古古', 10))  // '  古古古  '
+console.log(align.left('abc', 10))       // 'abc       '
+console.log(align.left('古古古', 10))    // '古古古    '
+console.log(align.right('abc', 10))      // '       abc'
+console.log(align.right('古古古', 10))   // '    古古古'
+```
+
+### Functions
+
+#### `align.center(str, length)` → `str`
+
+Returns *str* with spaces added to both sides such that that it is *length*
+chars long and centered in the spaces.
+
+#### `align.left(str, length)` → `str`
+
+Returns *str* with spaces to the right such that it is *length* chars long.
+
+### `align.right(str, length)` → `str`
+
+Returns *str* with spaces to the left such that it is *length* chars long.
+
+### Origins
+
+These functions were originally taken from 
+[cliui](https://npmjs.com/package/cliui). Changes include switching to the
+MUCH faster pad generation function from
+[lodash](https://npmjs.com/package/lodash), making center alignment pad
+both sides and adding left alignment.

--- a/node_modules/wrappy/README.md
+++ b/node_modules/wrappy/README.md
@@ -1,0 +1,36 @@
+# wrappy
+
+Callback wrapping utility
+
+## USAGE
+
+```javascript
+var wrappy = require("wrappy")
+
+// var wrapper = wrappy(wrapperFunction)
+
+// make sure a cb is called only once
+// See also: http://npm.im/once for this specific use case
+var once = wrappy(function (cb) {
+  var called = false
+  return function () {
+    if (called) return
+    called = true
+    return cb.apply(this, arguments)
+  }
+})
+
+function printBoo () {
+  console.log('boo')
+}
+// has some rando property
+printBoo.iAmBooPrinter = true
+
+var onlyPrintOnce = once(printBoo)
+
+onlyPrintOnce() // prints 'boo'
+onlyPrintOnce() // does nothing
+
+// random property is retained!
+assert.equal(onlyPrintOnce.iAmBooPrinter, true)
+```

--- a/node_modules/y18n/README.md
+++ b/node_modules/y18n/README.md
@@ -1,0 +1,109 @@
+# y18n
+
+[![Build Status][travis-image]][travis-url]
+[![Coverage Status][coveralls-image]][coveralls-url]
+[![NPM version][npm-image]][npm-url]
+[![js-standard-style][standard-image]][standard-url]
+[![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
+
+The bare-bones internationalization library used by yargs.
+
+Inspired by [i18n](https://www.npmjs.com/package/i18n).
+
+## Examples
+
+_simple string translation:_
+
+```js
+var __ = require('y18n').__
+
+console.log(__('my awesome string %s', 'foo'))
+```
+
+output:
+
+`my awesome string foo`
+
+_using tagged template literals_
+
+```js
+var __ = require('y18n').__
+var str = 'foo'
+
+console.log(__`my awesome string ${str}`)
+```
+
+output:
+
+`my awesome string foo`
+
+_pluralization support:_
+
+```js
+var __n = require('y18n').__n
+
+console.log(__n('one fish %s', '%d fishes %s', 2, 'foo'))
+```
+
+output:
+
+`2 fishes foo`
+
+## JSON Language Files
+
+The JSON language files should be stored in a `./locales` folder.
+File names correspond to locales, e.g., `en.json`, `pirate.json`.
+
+When strings are observed for the first time they will be
+added to the JSON file corresponding to the current locale.
+
+## Methods
+
+### require('y18n')(config)
+
+Create an instance of y18n with the config provided, options include:
+
+* `directory`: the locale directory, default `./locales`.
+* `updateFiles`: should newly observed strings be updated in file, default `true`.
+* `locale`: what locale should be used.
+* `fallbackToLanguage`: should fallback to a language-only file (e.g. `en.json`)
+  be allowed if a file matching the locale does not exist (e.g. `en_US.json`),
+  default `true`.
+
+### y18n.\_\_(str, arg, arg, arg)
+
+Print a localized string, `%s` will be replaced with `arg`s.
+
+This function can also be used as a tag for a template literal. You can use it
+like this: <code>__&#96;hello ${'world'}&#96;</code>. This will be equivalent to
+`__('hello %s', 'world')`.
+
+### y18n.\_\_n(singularString, pluralString, count, arg, arg, arg)
+
+Print a localized string with appropriate pluralization. If `%d` is provided
+in the string, the `count` will replace this placeholder.
+
+### y18n.setLocale(str)
+
+Set the current locale being used.
+
+### y18n.getLocale()
+
+What locale is currently being used?
+
+### y18n.updateLocale(obj)
+
+Update the current locale with the key value pairs in `obj`.
+
+## License
+
+ISC
+
+[travis-url]: https://travis-ci.org/yargs/y18n
+[travis-image]: https://img.shields.io/travis/yargs/y18n.svg
+[coveralls-url]: https://coveralls.io/github/yargs/y18n
+[coveralls-image]: https://img.shields.io/coveralls/yargs/y18n.svg
+[npm-url]: https://npmjs.org/package/y18n
+[npm-image]: https://img.shields.io/npm/v/y18n.svg
+[standard-image]: https://img.shields.io/badge/code%20style-standard-brightgreen.svg
+[standard-url]: https://github.com/feross/standard

--- a/node_modules/yargs-parser/README.md
+++ b/node_modules/yargs-parser/README.md
@@ -1,0 +1,350 @@
+# yargs-parser
+
+[![Build Status](https://travis-ci.org/yargs/yargs-parser.svg)](https://travis-ci.org/yargs/yargs-parser)
+[![Coverage Status](https://coveralls.io/repos/yargs/yargs-parser/badge.svg?branch=)](https://coveralls.io/r/yargs/yargs-parser?branch=master)
+[![NPM version](https://img.shields.io/npm/v/yargs-parser.svg)](https://www.npmjs.com/package/yargs-parser)
+[![Standard Version](https://img.shields.io/badge/release-standard%20version-brightgreen.svg)](https://github.com/conventional-changelog/standard-version)
+
+
+The mighty option parser used by [yargs](https://github.com/yargs/yargs).
+
+visit the [yargs website](http://yargs.js.org/) for more examples, and thorough usage instructions.
+
+<img width="250" src="https://raw.githubusercontent.com/yargs/yargs-parser/master/yargs-logo.png">
+
+## Example
+
+```sh
+npm i yargs-parser --save
+```
+
+```js
+var argv = require('yargs-parser')(process.argv.slice(2))
+console.log(argv)
+```
+
+```sh
+node example.js --foo=33 --bar hello
+{ _: [], foo: 33, bar: 'hello' }
+```
+
+_or parse a string!_
+
+```js
+var argv = require('./')('--foo=99 --bar=33')
+console.log(argv)
+```
+
+```sh
+{ _: [], foo: 99, bar: 33 }
+```
+
+Convert an array of mixed types before passing to `yargs-parser`:
+
+```js
+var parse = require('yargs-parser')
+parse(['-f', 11, '--zoom', 55].join(' '))   // <-- array to string
+parse(['-f', 11, '--zoom', 55].map(String)) // <-- array of strings
+```
+
+## API
+
+### require('yargs-parser')(args, opts={})
+
+Parses command line arguments returning a simple mapping of keys and values.
+
+**expects:**
+
+* `args`: a string or array of strings representing the options to parse.
+* `opts`: provide a set of hints indicating how `args` should be parsed:
+  * `opts.alias`: an object representing the set of aliases for a key: `{alias: {foo: ['f']}}`.
+  * `opts.array`: indicate that keys should be parsed as an array: `{array: ['foo', 'bar']}`.
+     Indicate that keys should be parsed as an array and coerced to booleans / numbers:
+     `{array: [{ key: 'foo', boolean: true }, {key: 'bar', number: true}]}`.
+  * `opts.boolean`: arguments should be parsed as booleans: `{boolean: ['x', 'y']}`.
+  * `opts.config`: indicate a key that represents a path to a configuration file (this file will be loaded and parsed).
+  * `opts.coerce`: provide a custom synchronous function that returns a coerced value from the argument provided
+    (or throws an error), e.g. `{coerce: {foo: function (arg) {return modifiedArg}}}`.
+  * `opts.count`: indicate a key that should be used as a counter, e.g., `-vvv` = `{v: 3}`.
+  * `opts.default`: provide default values for keys: `{default: {x: 33, y: 'hello world!'}}`.
+  * `opts.envPrefix`: environment variables (`process.env`) with the prefix provided should be parsed.
+  * `opts.narg`: specify that a key requires `n` arguments: `{narg: {x: 2}}`.
+  * `opts.normalize`: `path.normalize()` will be applied to values set to this key.
+  * `opts.string`: keys should be treated as strings (even if they resemble a number `-x 33`).
+  * `opts.configuration`: provide configuration options to the yargs-parser (see: [configuration](#configuration)).
+  * `opts.number`: keys should be treated as numbers.
+
+**returns:**
+
+* `obj`: an object representing the parsed value of `args`
+  * `key/value`: key value pairs for each argument and their aliases.
+  * `_`: an array representing the positional arguments.
+  * [optional] `--`:  an array with arguments after the end-of-options flag `--`.
+
+### require('yargs-parser').detailed(args, opts={})
+
+Parses a command line string, returning detailed information required by the
+yargs engine.
+
+**expects:**
+
+* `args`: a string or array of strings representing options to parse.
+* `opts`: provide a set of hints indicating how `args`, inputs are identical to `require('yargs-parser')(args, opts={})`.
+
+**returns:**
+
+* `argv`: an object representing the parsed value of `args`
+  * `key/value`: key value pairs for each argument and their aliases.
+  * `_`: an array representing the positional arguments.
+* `error`: populated with an error object if an exception occurred during parsing.
+* `aliases`: the inferred list of aliases built by combining lists in `opts.alias`.
+* `newAliases`: any new aliases added via camel-case expansion.
+* `configuration`: the configuration loaded from the `yargs` stanza in package.json.
+
+<a name="configuration"></a>
+
+### Configuration
+
+The yargs-parser applies several automated transformations on the keys provided
+in `args`. These features can be turned on and off using the `configuration` field
+of `opts`.
+
+```js
+var parsed = parser(['--no-dice'], {
+  configuration: {
+    'boolean-negation': false
+  }
+})
+```
+
+### short option groups
+
+* default: `true`.
+* key: `short-option-groups`.
+
+Should a group of short-options be treated as boolean flags?
+
+```sh
+node example.js -abc
+{ _: [], a: true, b: true, c: true }
+```
+
+_if disabled:_
+
+```sh
+node example.js -abc
+{ _: [], abc: true }
+```
+
+### camel-case expansion
+
+* default: `true`.
+* key: `camel-case-expansion`.
+
+Should hyphenated arguments be expanded into camel-case aliases?
+
+```sh
+node example.js --foo-bar
+{ _: [], 'foo-bar': true, fooBar: true }
+```
+
+_if disabled:_
+
+```sh
+node example.js --foo-bar
+{ _: [], 'foo-bar': true }
+```
+
+### dot-notation
+
+* default: `true`
+* key: `dot-notation`
+
+Should keys that contain `.` be treated as objects?
+
+```sh
+node example.js --foo.bar
+{ _: [], foo: { bar: true } }
+```
+
+_if disabled:_
+
+```sh
+node example.js --foo.bar
+{ _: [], "foo.bar": true }
+```
+
+### parse numbers
+
+* default: `true`
+* key: `parse-numbers`
+
+Should keys that look like numbers be treated as such?
+
+```sh
+node example.js --foo=99.3
+{ _: [], foo: 99.3 }
+```
+
+_if disabled:_
+
+```sh
+node example.js --foo=99.3
+{ _: [], foo: "99.3" }
+```
+
+### boolean negation
+
+* default: `true`
+* key: `boolean-negation`
+
+Should variables prefixed with `--no` be treated as negations?
+
+```sh
+node example.js --no-foo
+{ _: [], foo: false }
+```
+
+_if disabled:_
+
+```sh
+node example.js --no-foo
+{ _: [], "no-foo": true }
+```
+
+### combine arrays
+
+* default: `false`
+* key: `combine-arrays`
+
+Should arrays be combined when provided by both command line arguments and
+a configuration file.
+
+### duplicate arguments array
+
+* default: `true`
+* key: `duplicate-arguments-array`
+
+Should arguments be coerced into an array when duplicated:
+
+```sh
+node example.js -x 1 -x 2
+{ _: [], x: [1, 2] }
+```
+
+_if disabled:_
+
+```sh
+node example.js -x 1 -x 2
+{ _: [], x: 2 }
+```
+
+### flatten duplicate arrays
+
+* default: `true`
+* key: `flatten-duplicate-arrays`
+
+Should array arguments be coerced into a single array when duplicated:
+
+```sh
+node example.js -x 1 2 -x 3 4
+{ _: [], x: [1, 2, 3, 4] }
+```
+
+_if disabled:_
+
+```sh
+node example.js -x 1 2 -x 3 4
+{ _: [], x: [[1, 2], [3, 4]] }
+```
+
+### negation prefix
+
+* default: `no-`
+* key: `negation-prefix`
+
+The prefix to use for negated boolean variables.
+
+```sh
+node example.js --no-foo
+{ _: [], foo: false }
+```
+
+_if set to `quux`:_
+
+```sh
+node example.js --quuxfoo
+{ _: [], foo: false }
+```
+
+### populate --
+
+* default: `false`.
+* key: `populate--`
+
+Should unparsed flags be stored in `--` or `_`.
+
+_If disabled:_
+
+```sh
+node example.js a -b -- x y
+{ _: [ 'a', 'x', 'y' ], b: true }
+```
+
+_If enabled:_
+
+```sh
+node example.js a -b -- x y
+{ _: [ 'a' ], '--': [ 'x', 'y' ], b: true }
+```
+
+### set placeholder key
+
+* default: `false`.
+* key: `set-placeholder-key`.
+
+Should a placeholder be added for keys not set via the corresponding CLI argument?
+
+_If disabled:_
+
+```sh
+node example.js -a 1 -c 2
+{ _: [], a: 1, c: 2 }
+```
+
+_If enabled:_
+
+```sh
+node example.js -a 1 -c 2
+{ _: [], a: 1, b: undefined, c: 2 }
+```
+
+### halt at non-option
+
+* default: `false`.
+* key: `halt-at-non-option`.
+
+Should parsing stop at the first text argument? This is similar to how e.g. `ssh` parses its command line.
+
+_If disabled:_
+
+```sh
+node example.js -a run b -x y
+{ _: [ 'run', 'b', 'y' ], a: true, x: true }
+```
+
+_If enabled:_
+
+```sh
+node example.js -a run b -x y
+{ _: [ 'run', 'b', '-x', 'y' ], a: true }
+```
+
+## Special Thanks
+
+The yargs project evolves from optimist and minimist. It owes its
+existence to a lot of James Halliday's hard work. Thanks [substack](https://github.com/substack) **beep** **boop** \o/
+
+## License
+
+ISC

--- a/node_modules/yargs-unparser/README.md
+++ b/node_modules/yargs-unparser/README.md
@@ -1,0 +1,91 @@
+# yargs-unparser
+
+[![NPM version][npm-image]][npm-url] [![Downloads][downloads-image]][npm-url] [![Build Status][travis-image]][travis-url] [![Coverage Status][codecov-image]][codecov-url] [![Dependency status][david-dm-image]][david-dm-url] [![Dev Dependency status][david-dm-dev-image]][david-dm-dev-url] [![Greenkeeper badge][greenkeeper-image]][greenkeeper-url]
+
+[npm-url]:https://npmjs.org/package/yargs-unparser
+[npm-image]:http://img.shields.io/npm/v/yargs-unparser.svg
+[downloads-image]:http://img.shields.io/npm/dm/yargs-unparser.svg
+[travis-url]:https://travis-ci.org/yargs/yargs-unparser
+[travis-image]:http://img.shields.io/travis/yargs/yargs-unparser/master.svg
+[codecov-url]:https://codecov.io/gh/yargs/yargs-unparser
+[codecov-image]:https://img.shields.io/codecov/c/github/yargs/yargs-unparser/master.svg
+[david-dm-url]:https://david-dm.org/yargs/yargs-unparser
+[david-dm-image]:https://img.shields.io/david/yargs/yargs-unparser.svg
+[david-dm-dev-url]:https://david-dm.org/yargs/yargs-unparser?type=dev
+[david-dm-dev-image]:https://img.shields.io/david/dev/yargs/yargs-unparser.svg
+[greenkeeper-image]:https://badges.greenkeeper.io/yargs/yargs-unparser.svg
+[greenkeeper-url]:https://greenkeeper.io
+
+Converts back a `yargs` argv object to its original array form.
+
+Probably the unparser word doesn't even exist, but it sounds nice and goes well with [yargs-parser](https://github.com/yargs/yargs-parser).
+
+The code originally lived in [MOXY](https://github.com/moxystudio)'s GitHub but was later moved here for discoverability.
+
+
+## Installation
+
+`$ npm install yargs-unparser`
+
+
+## Usage
+
+```js
+const parse = require('yargs-parser');
+const unparse = require('yargs-unparser');
+
+const argv = parse(['--no-boolean', '--number', '4', '--string', 'foo'], {
+    boolean: ['boolean'],
+    number: ['number'],
+    string: ['string'],
+});
+// { boolean: false, number: 4, string: 'foo', _: [] }
+
+const unparsedArgv = unparse(argv);
+// ['--no-boolean', '--number', '4', '--string', 'foo'];
+```
+
+The second argument of `unparse` accepts an options object:
+
+- `alias`: The [aliases](https://github.com/yargs/yargs-parser#requireyargs-parserargs-opts) so that duplicate options aren't generated
+- `default`: The [default](https://github.com/yargs/yargs-parser#requireyargs-parserargs-opts) values so that the options with default values are omitted
+- `command`: The [command](https://github.com/yargs/yargs/blob/master/docs/advanced.md#commands) first argument so that command names and positional arguments are handled correctly
+
+### Example with `command` options
+
+```js
+const yargs = require('yargs');
+const unparse = require('yargs-unparse');
+
+const argv = yargs
+    .command('my-command <positional>', 'My awesome command', (yargs) =>
+        yargs
+        .option('boolean', { type: 'boolean' })
+        .option('number', { type: 'number' })
+        .option('string', { type: 'string' })
+    )
+    .parse(['my-command', 'hello', '--no-boolean', '--number', '4', '--string', 'foo']);
+// { positional: 'hello', boolean: false, number: 4, string: 'foo', _: ['my-command'] }
+
+const unparsedArgv = unparse(argv, {
+    command: 'my-command <positional>',
+});
+// ['my-command', 'hello', '--no-boolean', '--number', '4', '--string', 'foo'];
+```
+
+### Caveats
+
+The returned array can be parsed again by `yargs-parser` using the default configuration. If you used custom configuration that you want `yargs-unparser` to be aware, please fill an [issue](https://github.com/yargs/yargs-unparser/issues).
+
+If you `coerce` in weird ways, things might not work correctly.
+
+
+## Tests
+
+`$ npm test`   
+`$ npm test -- --watch` during development
+
+
+## License
+
+[MIT License](http://opensource.org/licenses/MIT)

--- a/node_modules/yargs-unparser/node_modules/get-caller-file/README.md
+++ b/node_modules/yargs-unparser/node_modules/get-caller-file/README.md
@@ -1,0 +1,4 @@
+# get-caller-file
+
+[![Build Status](https://travis-ci.org/stefanpenner/get-caller-file.svg?branch=master)](https://travis-ci.org/stefanpenner/get-caller-file)
+[![Build status](https://ci.appveyor.com/api/projects/status/ol2q94g1932cy14a/branch/master?svg=true)](https://ci.appveyor.com/project/embercli/get-caller-file/branch/master)

--- a/node_modules/yargs-unparser/node_modules/require-main-filename/README.md
+++ b/node_modules/yargs-unparser/node_modules/require-main-filename/README.md
@@ -1,0 +1,26 @@
+# require-main-filename
+
+[![Build Status](https://travis-ci.org/yargs/require-main-filename.png)](https://travis-ci.org/yargs/require-main-filename)
+[![Coverage Status](https://coveralls.io/repos/yargs/require-main-filename/badge.svg?branch=master)](https://coveralls.io/r/yargs/require-main-filename?branch=master)
+[![NPM version](https://img.shields.io/npm/v/require-main-filename.svg)](https://www.npmjs.com/package/require-main-filename)
+
+`require.main.filename` is great for figuring out the entry
+point for the current application. This can be combined with a module like
+[pkg-conf](https://www.npmjs.com/package/pkg-conf) to, _as if by magic_, load
+top-level configuration.
+
+Unfortunately, `require.main.filename` sometimes fails when an application is
+executed with an alternative process manager, e.g., [iisnode](https://github.com/tjanczuk/iisnode).
+
+`require-main-filename` is a shim that addresses this problem.
+
+## Usage
+
+```js
+var main = require('require-main-filename')()
+// use main as an alternative to require.main.filename.
+```
+
+## License
+
+ISC

--- a/node_modules/yargs-unparser/node_modules/yargs-parser/README.md
+++ b/node_modules/yargs-unparser/node_modules/yargs-parser/README.md
@@ -1,0 +1,351 @@
+# yargs-parser
+
+[![Build Status](https://travis-ci.org/yargs/yargs-parser.svg)](https://travis-ci.org/yargs/yargs-parser)
+[![Coverage Status](https://coveralls.io/repos/yargs/yargs-parser/badge.svg?branch=)](https://coveralls.io/r/yargs/yargs-parser?branch=master)
+[![NPM version](https://img.shields.io/npm/v/yargs-parser.svg)](https://www.npmjs.com/package/yargs-parser)
+[![Standard Version](https://img.shields.io/badge/release-standard%20version-brightgreen.svg)](https://github.com/conventional-changelog/standard-version)
+
+
+The mighty option parser used by [yargs](https://github.com/yargs/yargs).
+
+visit the [yargs website](http://yargs.js.org/) for more examples, and thorough usage instructions.
+
+<img width="250" src="https://raw.githubusercontent.com/yargs/yargs-parser/master/yargs-logo.png">
+
+## Example
+
+```sh
+npm i yargs-parser --save
+```
+
+```js
+var argv = require('yargs-parser')(process.argv.slice(2))
+console.log(argv)
+```
+
+```sh
+node example.js --foo=33 --bar hello
+{ _: [], foo: 33, bar: 'hello' }
+```
+
+_or parse a string!_
+
+```js
+var argv = require('./')('--foo=99 --bar=33')
+console.log(argv)
+```
+
+```sh
+{ _: [], foo: 99, bar: 33 }
+```
+
+Convert an array of mixed types before passing to `yargs-parser`:
+
+```js
+var parse = require('yargs-parser')
+parse(['-f', 11, '--zoom', 55].join(' '))   // <-- array to string
+parse(['-f', 11, '--zoom', 55].map(String)) // <-- array of strings
+```
+
+## API
+
+### require('yargs-parser')(args, opts={})
+
+Parses command line arguments returning a simple mapping of keys and values.
+
+**expects:**
+
+* `args`: a string or array of strings representing the options to parse.
+* `opts`: provide a set of hints indicating how `args` should be parsed:
+  * `opts.alias`: an object representing the set of aliases for a key: `{alias: {foo: ['f']}}`.
+  * `opts.array`: indicate that keys should be parsed as an array: `{array: ['foo', 'bar']}`.
+     Indicate that keys should be parsed as an array and coerced to booleans / numbers:
+     `{array: [{ key: 'foo', boolean: true }, {key: 'bar', number: true}]}`.
+  * `opts.boolean`: arguments should be parsed as booleans: `{boolean: ['x', 'y']}`.
+  * `opts.config`: indicate a key that represents a path to a configuration file (this file will be loaded and parsed).
+  * `opts.coerce`: provide a custom synchronous function that returns a coerced value from the argument provided
+    (or throws an error), e.g. `{coerce: {foo: function (arg) {return modifiedArg}}}`.
+  * `opts.count`: indicate a key that should be used as a counter, e.g., `-vvv` = `{v: 3}`.
+  * `opts.default`: provide default values for keys: `{default: {x: 33, y: 'hello world!'}}`.
+  * `opts.envPrefix`: environment variables (`process.env`) with the prefix provided should be parsed.
+  * `opts.narg`: specify that a key requires `n` arguments: `{narg: {x: 2}}`.
+  * `opts.normalize`: `path.normalize()` will be applied to values set to this key.
+  * `opts.string`: keys should be treated as strings (even if they resemble a number `-x 33`).
+  * `opts.configuration`: provide configuration options to the yargs-parser (see: [configuration](#configuration)).
+  * `opts.number`: keys should be treated as numbers.
+  * `opts['--']`: arguments after the end-of-options flag `--` will be set to the `argv.['--']` array instead of being set to the `argv._` array.
+
+**returns:**
+
+* `obj`: an object representing the parsed value of `args`
+  * `key/value`: key value pairs for each argument and their aliases.
+  * `_`: an array representing the positional arguments.
+  * [optional] `--`:  an array with arguments after the end-of-options flag `--`.
+
+### require('yargs-parser').detailed(args, opts={})
+
+Parses a command line string, returning detailed information required by the
+yargs engine.
+
+**expects:**
+
+* `args`: a string or array of strings representing options to parse.
+* `opts`: provide a set of hints indicating how `args`, inputs are identical to `require('yargs-parser')(args, opts={})`.
+
+**returns:**
+
+* `argv`: an object representing the parsed value of `args`
+  * `key/value`: key value pairs for each argument and their aliases.
+  * `_`: an array representing the positional arguments.
+* `error`: populated with an error object if an exception occurred during parsing.
+* `aliases`: the inferred list of aliases built by combining lists in `opts.alias`.
+* `newAliases`: any new aliases added via camel-case expansion.
+* `configuration`: the configuration loaded from the `yargs` stanza in package.json.
+
+<a name="configuration"></a>
+
+### Configuration
+
+The yargs-parser applies several automated transformations on the keys provided
+in `args`. These features can be turned on and off using the `configuration` field
+of `opts`.
+
+```js
+var parsed = parser(['--no-dice'], {
+  configuration: {
+    'boolean-negation': false
+  }
+})
+```
+
+### short option groups
+
+* default: `true`.
+* key: `short-option-groups`.
+
+Should a group of short-options be treated as boolean flags?
+
+```sh
+node example.js -abc
+{ _: [], a: true, b: true, c: true }
+```
+
+_if disabled:_
+
+```sh
+node example.js -abc
+{ _: [], abc: true }
+```
+
+### camel-case expansion
+
+* default: `true`.
+* key: `camel-case-expansion`.
+
+Should hyphenated arguments be expanded into camel-case aliases?
+
+```sh
+node example.js --foo-bar
+{ _: [], 'foo-bar': true, fooBar: true }
+```
+
+_if disabled:_
+
+```sh
+node example.js --foo-bar
+{ _: [], 'foo-bar': true }
+```
+
+### dot-notation
+
+* default: `true`
+* key: `dot-notation`
+
+Should keys that contain `.` be treated as objects?
+
+```sh
+node example.js --foo.bar
+{ _: [], foo: { bar: true } }
+```
+
+_if disabled:_
+
+```sh
+node example.js --foo.bar
+{ _: [], "foo.bar": true }
+```
+
+### parse numbers
+
+* default: `true`
+* key: `parse-numbers`
+
+Should keys that look like numbers be treated as such?
+
+```sh
+node example.js --foo=99.3
+{ _: [], foo: 99.3 }
+```
+
+_if disabled:_
+
+```sh
+node example.js --foo=99.3
+{ _: [], foo: "99.3" }
+```
+
+### boolean negation
+
+* default: `true`
+* key: `boolean-negation`
+
+Should variables prefixed with `--no` be treated as negations?
+
+```sh
+node example.js --no-foo
+{ _: [], foo: false }
+```
+
+_if disabled:_
+
+```sh
+node example.js --no-foo
+{ _: [], "no-foo": true }
+```
+
+### combine arrays
+
+* default: `false`
+* key: `combine-arrays`
+
+Should arrays be combined when provided by both command line arguments and
+a configuration file.
+
+### duplicate arguments array
+
+* default: `true`
+* key: `duplicate-arguments-array`
+
+Should arguments be coerced into an array when duplicated:
+
+```sh
+node example.js -x 1 -x 2
+{ _: [], x: [1, 2] }
+```
+
+_if disabled:_
+
+```sh
+node example.js -x 1 -x 2
+{ _: [], x: 2 }
+```
+
+### flatten duplicate arrays
+
+* default: `true`
+* key: `flatten-duplicate-arrays`
+
+Should array arguments be coerced into a single array when duplicated:
+
+```sh
+node example.js -x 1 2 -x 3 4
+{ _: [], x: [1, 2, 3, 4] }
+```
+
+_if disabled:_
+
+```sh
+node example.js -x 1 2 -x 3 4
+{ _: [], x: [[1, 2], [3, 4]] }
+```
+
+### negation prefix
+
+* default: `no-`
+* key: `negation-prefix`
+
+The prefix to use for negated boolean variables.
+
+```sh
+node example.js --no-foo
+{ _: [], foo: false }
+```
+
+_if set to `quux`:_
+
+```sh
+node example.js --quuxfoo
+{ _: [], foo: false }
+```
+
+### populate --
+
+* default: `false`.
+* key: `populate--`
+
+Should unparsed flags be stored in `--` or `_`.
+
+_If disabled:_
+
+```sh
+node example.js a -b -- x y
+{ _: [ 'a', 'x', 'y' ], b: true }
+```
+
+_If enabled:_
+
+```sh
+node example.js a -b -- x y
+{ _: [ 'a' ], '--': [ 'x', 'y' ], b: true }
+```
+
+### set placeholder key
+
+* default: `false`.
+* key: `set-placeholder-key`.
+
+Should a placeholder be added for keys not set via the corresponding CLI argument?
+
+_If disabled:_
+
+```sh
+node example.js -a 1 -c 2
+{ _: [], a: 1, c: 2 }
+```
+
+_If enabled:_
+
+```sh
+node example.js -a 1 -c 2
+{ _: [], a: 1, b: undefined, c: 2 }
+```
+
+### halt at non-option
+
+* default: `false`.
+* key: `halt-at-non-option`.
+
+Should parsing stop at the first text argument? This is similar to how e.g. `ssh` parses its command line.
+
+_If disabled:_
+
+```sh
+node example.js -a run b -x y
+{ _: [ 'run', 'b', 'y' ], a: true, x: true }
+```
+
+_If enabled:_
+
+```sh
+node example.js -a run b -x y
+{ _: [ 'run', 'b', '-x', 'y' ], a: true }
+```
+
+## Special Thanks
+
+The yargs project evolves from optimist and minimist. It owes its
+existence to a lot of James Halliday's hard work. Thanks [substack](https://github.com/substack) **beep** **boop** \o/
+
+## License
+
+ISC

--- a/node_modules/yargs-unparser/node_modules/yargs/README.md
+++ b/node_modules/yargs-unparser/node_modules/yargs/README.md
@@ -1,0 +1,122 @@
+<p align="center">
+  <img width="250" src="/yargs-logo.png">
+</p>
+<h1 align="center"> Yargs </h1>
+<p align="center">
+  <b >Yargs be a node.js library fer hearties tryin' ter parse optstrings</b>
+</p>
+<br>
+
+[![Build Status][travis-image]][travis-url]
+[![Coverage Status][coveralls-image]][coveralls-url]
+[![NPM version][npm-image]][npm-url]
+[![js-standard-style][standard-image]][standard-url]
+[![Conventional Commits][conventional-commits-image]][conventional-commits-url]
+[![Slack][slack-image]][slack-url]
+
+## Description :
+Yargs helps you build interactive command line tools, by parsing arguments and generating an elegant user interface. 
+
+It gives you:
+
+* commands and (grouped) options (`my-program.js serve --port=5000`).
+* a dynamically generated help menu based on your arguments.
+
+> <img width="400" src="/screen.png">
+
+* bash-completion shortcuts for commands and options.
+* and [tons more](/docs/api.md).
+
+## Installation
+
+Stable version:
+```bash
+npm i yargs --save
+```
+
+Bleeding edge version with the most recent features:
+```bash
+npm i yargs@next --save
+```
+
+## Usage :
+
+### Simple Example
+
+````javascript
+#!/usr/bin/env node
+const argv = require('yargs').argv
+
+if (argv.ships > 3 && argv.distance < 53.5) {
+  console.log('Plunder more riffiwobbles!')
+} else {
+  console.log('Retreat from the xupptumblers!')
+}
+````
+
+```bash
+$ ./plunder.js --ships=4 --distance=22
+Plunder more riffiwobbles!
+
+$ ./plunder.js --ships 12 --distance 98.7
+Retreat from the xupptumblers!
+```
+
+### Complex Example
+
+```javascript
+#!/usr/bin/env node
+require('yargs') // eslint-disable-line
+  .command('serve [port]', 'start the server', (yargs) => {
+    yargs
+      .positional('port', {
+        describe: 'port to bind on',
+        default: 5000
+      })
+  }, (argv) => {
+    if (argv.verbose) console.info(`start server on :${argv.port}`)
+    serve(argv.port)
+  })
+  .option('verbose', {
+    alias: 'v',
+    default: false
+  })
+  .argv
+```
+
+Run the example above with `--help` to see the help for the application.
+
+## Community :
+
+Having problems? want to contribute? join our [community slack](http://devtoolscommunity.herokuapp.com).
+
+## Documentation :
+
+### Table of Contents
+
+* [Yargs' API](/docs/api.md)
+* [Examples](/docs/examples.md)
+* [Parsing Tricks](/docs/tricks.md)
+  * [Stop the Parser](/docs/tricks.md#stop)
+  * [Negating Boolean Arguments](/docs/tricks.md#negate)
+  * [Numbers](/docs/tricks.md#numbers)
+  * [Arrays](/docs/tricks.md#arrays)
+  * [Objects](/docs/tricks.md#objects)
+* [Advanced Topics](/docs/advanced.md)
+  * [Composing Your App Using Commands](/docs/advanced.md#commands)
+  * [Building Configurable CLI Apps](/docs/advanced.md#configuration)
+  * [Customizing Yargs' Parser](/docs/advanced.md#customizing)
+* [Contributing](/contributing.md)
+
+[travis-url]: https://travis-ci.org/yargs/yargs
+[travis-image]: https://img.shields.io/travis/yargs/yargs/master.svg
+[coveralls-url]: https://coveralls.io/github/yargs/yargs
+[coveralls-image]: https://img.shields.io/coveralls/yargs/yargs.svg
+[npm-url]: https://www.npmjs.com/package/yargs
+[npm-image]: https://img.shields.io/npm/v/yargs.svg
+[standard-image]: https://img.shields.io/badge/code%20style-standard-brightgreen.svg
+[standard-url]: http://standardjs.com/
+[conventional-commits-image]: https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg
+[conventional-commits-url]: https://conventionalcommits.org/
+[slack-image]: http://devtoolscommunity.herokuapp.com/badge.svg
+[slack-url]: http://devtoolscommunity.herokuapp.com

--- a/node_modules/yargs/README.md
+++ b/node_modules/yargs/README.md
@@ -1,0 +1,122 @@
+<p align="center">
+  <img width="250" src="/yargs-logo.png">
+</p>
+<h1 align="center"> Yargs </h1>
+<p align="center">
+  <b >Yargs be a node.js library fer hearties tryin' ter parse optstrings</b>
+</p>
+<br>
+
+[![Build Status][travis-image]][travis-url]
+[![Coverage Status][coveralls-image]][coveralls-url]
+[![NPM version][npm-image]][npm-url]
+[![js-standard-style][standard-image]][standard-url]
+[![Conventional Commits][conventional-commits-image]][conventional-commits-url]
+[![Slack][slack-image]][slack-url]
+
+## Description :
+Yargs helps you build interactive command line tools, by parsing arguments and generating an elegant user interface. 
+
+It gives you:
+
+* commands and (grouped) options (`my-program.js serve --port=5000`).
+* a dynamically generated help menu based on your arguments.
+
+> <img width="400" src="/screen.png">
+
+* bash-completion shortcuts for commands and options.
+* and [tons more](/docs/api.md).
+
+## Installation
+
+Stable version:
+```bash
+npm i yargs
+```
+
+Bleeding edge version with the most recent features:
+```bash
+npm i yargs@next
+```
+
+## Usage :
+
+### Simple Example
+
+````javascript
+#!/usr/bin/env node
+const argv = require('yargs').argv
+
+if (argv.ships > 3 && argv.distance < 53.5) {
+  console.log('Plunder more riffiwobbles!')
+} else {
+  console.log('Retreat from the xupptumblers!')
+}
+````
+
+```bash
+$ ./plunder.js --ships=4 --distance=22
+Plunder more riffiwobbles!
+
+$ ./plunder.js --ships 12 --distance 98.7
+Retreat from the xupptumblers!
+```
+
+### Complex Example
+
+```javascript
+#!/usr/bin/env node
+require('yargs') // eslint-disable-line
+  .command('serve [port]', 'start the server', (yargs) => {
+    yargs
+      .positional('port', {
+        describe: 'port to bind on',
+        default: 5000
+      })
+  }, (argv) => {
+    if (argv.verbose) console.info(`start server on :${argv.port}`)
+    serve(argv.port)
+  })
+  .option('verbose', {
+    alias: 'v',
+    default: false
+  })
+  .argv
+```
+
+Run the example above with `--help` to see the help for the application.
+
+## Community :
+
+Having problems? want to contribute? join our [community slack](http://devtoolscommunity.herokuapp.com).
+
+## Documentation :
+
+### Table of Contents
+
+* [Yargs' API](/docs/api.md)
+* [Examples](/docs/examples.md)
+* [Parsing Tricks](/docs/tricks.md)
+  * [Stop the Parser](/docs/tricks.md#stop)
+  * [Negating Boolean Arguments](/docs/tricks.md#negate)
+  * [Numbers](/docs/tricks.md#numbers)
+  * [Arrays](/docs/tricks.md#arrays)
+  * [Objects](/docs/tricks.md#objects)
+* [Advanced Topics](/docs/advanced.md)
+  * [Composing Your App Using Commands](/docs/advanced.md#commands)
+  * [Building Configurable CLI Apps](/docs/advanced.md#configuration)
+  * [Customizing Yargs' Parser](/docs/advanced.md#customizing)
+* [Contributing](/contributing.md)
+
+[travis-url]: https://travis-ci.org/yargs/yargs
+[travis-image]: https://img.shields.io/travis/yargs/yargs/master.svg
+[coveralls-url]: https://coveralls.io/github/yargs/yargs
+[coveralls-image]: https://img.shields.io/coveralls/yargs/yargs.svg
+[npm-url]: https://www.npmjs.com/package/yargs
+[npm-image]: https://img.shields.io/npm/v/yargs.svg
+[standard-image]: https://img.shields.io/badge/code%20style-standard-brightgreen.svg
+[standard-url]: http://standardjs.com/
+[conventional-commits-image]: https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg
+[conventional-commits-url]: https://conventionalcommits.org/
+[slack-image]: http://devtoolscommunity.herokuapp.com/badge.svg
+[slack-url]: http://devtoolscommunity.herokuapp.com

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
   <groupId>com.google.oauth-client</groupId>
   <artifactId>google-oauth-client-parent</artifactId>
-  <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-oauth-client:current} -->
+  <version>1.29.0</version><!-- {x-version-update:google-oauth-client:current} -->
   <packaging>pom</packaging>
   <name>Parent for the Google OAuth Client Library for Java</name>
 

--- a/samples/dailymotion-cmdline-sample/pom.xml
+++ b/samples/dailymotion-cmdline-sample/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.oauth-client</groupId>
     <artifactId>google-oauth-client-parent</artifactId>
-    <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-oauth-client:current} -->
+    <version>1.29.0</version><!-- {x-version-update:google-oauth-client:current} -->
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>dailymotion-simple-cmdline-sample</artifactId>

--- a/versions.txt
+++ b/versions.txt
@@ -1,4 +1,4 @@
 # Format:
 # module:released-version:current-version
 
-google-oauth-client:1.28.0:1.28.1-SNAPSHOT
+google-oauth-client:1.29.0:1.29.0


### PR DESCRIPTION
This pull request was generated using releasetool.

05-14-2019 10:06 PDT

### Dependencies
- Update to google-http-client 1.29.1

### Documentation
- Update javadoc links to point to googleapis.dev ([#256](https://github.com/google/google-oauth-java-client/pull/256))

### Internal / Testing Changes
- Add publish_javadoc kokoro job ([#253](https://github.com/google/google-oauth-java-client/pull/253))
- Cleanup assembly proceses ([#243](https://github.com/google/google-oauth-java-client/pull/243))