### PR TITLE
Convert from google-http-client-jackson to google-http-client-jackson2

### DIFF
--- a/google-oauth-client-assembly/assembly.xml
+++ b/google-oauth-client-assembly/assembly.xml
@@ -51,12 +51,6 @@
       <filtered>true</filtered>
     </file>
     <file>
-      <source>properties/google-http-client-jackson.jar.properties</source>
-      <destName>google-http-client-jackson-${project.http.version}.jar.properties</destName>
-      <outputDirectory>google-oauth-java-client/libs</outputDirectory>
-      <filtered>true</filtered>
-    </file>
-    <file>
       <source>properties/google-http-client-jackson2.jar.properties</source>
       <destName>google-http-client-jackson2-${project.http.version}.jar.properties</destName>
       <outputDirectory>google-oauth-java-client/libs</outputDirectory>
@@ -83,12 +77,6 @@
     <file>
       <source>properties/jackson-core.jar.properties</source>
       <destName>jackson-core-${project.jackson-core2.version}.jar.properties</destName>
-      <outputDirectory>google-oauth-java-client/libs</outputDirectory>
-      <filtered>true</filtered>
-    </file>
-    <file>
-      <source>properties/jackson-core-asl.jar.properties</source>
-      <destName>jackson-core-asl-${project.jackson-core-asl.version}.jar.properties</destName>
       <outputDirectory>google-oauth-java-client/libs</outputDirectory>
       <filtered>true</filtered>
     </file>

--- a/google-oauth-client-assembly/properties/google-http-client-jackson.jar.properties
+++ b/google-oauth-client-assembly/properties/google-http-client-jackson.jar.properties
@@ -1,1 +1,0 @@
-src=../libs-sources/google-http-client-jackson-${project.http.version}-sources.jar

--- a/google-oauth-client-assembly/properties/jackson-core-asl.jar.properties
+++ b/google-oauth-client-assembly/properties/jackson-core-asl.jar.properties
@@ -1,1 +1,0 @@
-src=../libs-sources/jackson-core-asl-${project.jackson-core-asl.version}-sources.jar

--- a/google-oauth-client-java6/pom.xml
+++ b/google-oauth-client-java6/pom.xml
@@ -85,7 +85,7 @@
     </dependency>
     <dependency>
       <groupId>com.google.http-client</groupId>
-      <artifactId>google-http-client-jackson</artifactId>
+      <artifactId>google-http-client-jackson2</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/google-oauth-client-java6/src/test/java/com/google/api/client/extensions/java6/auth/oauth2/FileCredentialStoreTest.java
+++ b/google-oauth-client-java6/src/test/java/com/google/api/client/extensions/java6/auth/oauth2/FileCredentialStoreTest.java
@@ -25,7 +25,7 @@ import com.google.api.client.http.LowLevelHttpRequest;
 import com.google.api.client.http.LowLevelHttpResponse;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.JsonGenerator;
-import com.google.api.client.json.jackson.JacksonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.client.testing.http.MockHttpTransport;
 import com.google.api.client.testing.http.MockLowLevelHttpRequest;
 import com.google.api.client.testing.http.MockLowLevelHttpResponse;

--- a/google-oauth-client/pom.xml
+++ b/google-oauth-client/pom.xml
@@ -82,7 +82,7 @@
     </dependency>
     <dependency>
       <groupId>com.google.http-client</groupId>
-      <artifactId>google-http-client-jackson</artifactId>
+      <artifactId>google-http-client-jackson2</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/google-oauth-client/src/test/java/com/google/api/client/auth/oauth2/AuthenticationTestBase.java
+++ b/google-oauth-client/src/test/java/com/google/api/client/auth/oauth2/AuthenticationTestBase.java
@@ -19,7 +19,7 @@ import com.google.api.client.http.LowLevelHttpRequest;
 import com.google.api.client.http.LowLevelHttpResponse;
 import com.google.api.client.json.Json;
 import com.google.api.client.json.JsonFactory;
-import com.google.api.client.json.jackson.JacksonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.client.testing.http.MockHttpTransport;
 import com.google.api.client.testing.http.MockLowLevelHttpRequest;
 import com.google.api.client.testing.http.MockLowLevelHttpResponse;

--- a/google-oauth-client/src/test/java/com/google/api/client/auth/oauth2/AuthorizationCodeFlowTest.java
+++ b/google-oauth-client/src/test/java/com/google/api/client/auth/oauth2/AuthorizationCodeFlowTest.java
@@ -16,7 +16,7 @@ package com.google.api.client.auth.oauth2;
 
 import com.google.api.client.auth.oauth2.AuthorizationCodeFlow.CredentialCreatedListener;
 import com.google.api.client.http.BasicAuthentication;
-import com.google.api.client.json.jackson.JacksonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.client.util.Joiner;
 
 import java.io.IOException;

--- a/google-oauth-client/src/test/java/com/google/api/client/auth/oauth2/CustomTokenRequestTest.java
+++ b/google-oauth-client/src/test/java/com/google/api/client/auth/oauth2/CustomTokenRequestTest.java
@@ -20,7 +20,7 @@ import com.google.api.client.http.GenericUrl;
 import com.google.api.client.http.LowLevelHttpRequest;
 import com.google.api.client.http.LowLevelHttpResponse;
 import com.google.api.client.json.Json;
-import com.google.api.client.json.jackson.JacksonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.client.testing.http.MockHttpTransport;
 
 import com.google.api.client.testing.http.MockLowLevelHttpRequest;

--- a/google-oauth-client/src/test/java/com/google/api/client/auth/oauth2/CustomTokenResponseTest.java
+++ b/google-oauth-client/src/test/java/com/google/api/client/auth/oauth2/CustomTokenResponseTest.java
@@ -15,7 +15,7 @@
 package com.google.api.client.auth.oauth2;
 
 import com.google.api.client.json.JsonFactory;
-import com.google.api.client.json.jackson.JacksonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
 
 import com.google.api.client.util.Key;
 import junit.framework.TestCase;

--- a/google-oauth-client/src/test/java/com/google/api/client/auth/oauth2/TokenErrorResponseTest.java
+++ b/google-oauth-client/src/test/java/com/google/api/client/auth/oauth2/TokenErrorResponseTest.java
@@ -15,7 +15,7 @@
 package com.google.api.client.auth.oauth2;
 
 import com.google.api.client.json.JsonFactory;
-import com.google.api.client.json.jackson.JacksonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
 
 import junit.framework.TestCase;
 

--- a/google-oauth-client/src/test/java/com/google/api/client/auth/oauth2/TokenRequestTest.java
+++ b/google-oauth-client/src/test/java/com/google/api/client/auth/oauth2/TokenRequestTest.java
@@ -15,7 +15,7 @@
 package com.google.api.client.auth.oauth2;
 
 import com.google.api.client.http.GenericUrl;
-import com.google.api.client.json.jackson.JacksonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.client.testing.http.MockHttpTransport;
 
 import junit.framework.TestCase;

--- a/google-oauth-client/src/test/java/com/google/api/client/auth/oauth2/TokenResponseTest.java
+++ b/google-oauth-client/src/test/java/com/google/api/client/auth/oauth2/TokenResponseTest.java
@@ -15,7 +15,7 @@
 package com.google.api.client.auth.oauth2;
 
 import com.google.api.client.json.JsonFactory;
-import com.google.api.client.json.jackson.JacksonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
 
 import junit.framework.TestCase;
 


### PR DESCRIPTION
Jackson 1.x has been unsupported for a long time. Switch to using the
google-http-client-jackson2 parsing adapter which uses Jackson 2.x.
These usages came only from tests.
