### PR TITLE
Release google-oauth-java-client v1.30.0

### DIFF
--- a/google-oauth-client-appengine/pom.xml
+++ b/google-oauth-client-appengine/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.oauth-client</groupId>
     <artifactId>google-oauth-client-parent</artifactId>
-    <version>1.29.1-SNAPSHOT</version><!-- {x-version-update:google-oauth-client:current} -->
+    <version>1.30.0</version><!-- {x-version-update:google-oauth-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-oauth-client-appengine</artifactId>

--- a/google-oauth-client-assembly/pom.xml
+++ b/google-oauth-client-assembly/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.oauth-client</groupId>
     <artifactId>google-oauth-client-parent</artifactId>
-    <version>1.29.1-SNAPSHOT</version><!-- {x-version-update:google-oauth-client:current} -->
+    <version>1.30.0</version><!-- {x-version-update:google-oauth-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <groupId>com.google.oauth-client</groupId>

--- a/google-oauth-client-bom/README.md
+++ b/google-oauth-client-bom/README.md
@@ -12,7 +12,7 @@ To use it in Maven, add the following to your `pom.xml`:
     <dependency>
       <groupId>com.google.oauth-client</groupId>
       <artifactId>google-oauth-client-bom</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>

--- a/google-oauth-client-bom/pom.xml
+++ b/google-oauth-client-bom/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.oauth-client</groupId>
   <artifactId>google-oauth-client-bom</artifactId>
-  <version>1.29.1-SNAPSHOT</version><!-- {x-version-update:google-oauth-client:current} -->
+  <version>1.30.0</version><!-- {x-version-update:google-oauth-client:current} -->
   <packaging>pom</packaging>
 
   <name>Google OAuth Client Library for Java BOM</name>
@@ -63,32 +63,32 @@
       <dependency>
         <groupId>com.google.oauth-client</groupId>
         <artifactId>google-oauth-client</artifactId>
-        <version>1.29.1-SNAPSHOT</version><!-- {x-version-update:google-oauth-client:current} -->
+        <version>1.30.0</version><!-- {x-version-update:google-oauth-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.oauth-client</groupId>
         <artifactId>google-oauth-client-appengine</artifactId>
-        <version>1.29.1-SNAPSHOT</version><!-- {x-version-update:google-oauth-client:current} -->
+        <version>1.30.0</version><!-- {x-version-update:google-oauth-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.oauth-client</groupId>
         <artifactId>google-oauth-client-assembly</artifactId>
-        <version>1.29.1-SNAPSHOT</version><!-- {x-version-update:google-oauth-client:current} -->
+        <version>1.30.0</version><!-- {x-version-update:google-oauth-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.oauth-client</groupId>
         <artifactId>google-oauth-client-java6</artifactId>
-        <version>1.29.1-SNAPSHOT</version><!-- {x-version-update:google-oauth-client:current} -->
+        <version>1.30.0</version><!-- {x-version-update:google-oauth-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.oauth-client</groupId>
         <artifactId>google-oauth-client-jetty</artifactId>
-        <version>1.29.1-SNAPSHOT</version><!-- {x-version-update:google-oauth-client:current} -->
+        <version>1.30.0</version><!-- {x-version-update:google-oauth-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.oauth-client</groupId>
         <artifactId>google-oauth-client-servlet</artifactId>
-        <version>1.29.1-SNAPSHOT</version><!-- {x-version-update:google-oauth-client:current} -->
+        <version>1.30.0</version><!-- {x-version-update:google-oauth-client:current} -->
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/google-oauth-client-java6/pom.xml
+++ b/google-oauth-client-java6/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.oauth-client</groupId>
     <artifactId>google-oauth-client-parent</artifactId>
-    <version>1.29.1-SNAPSHOT</version><!-- {x-version-update:google-oauth-client:current} -->
+    <version>1.30.0</version><!-- {x-version-update:google-oauth-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-oauth-client-java6</artifactId>

--- a/google-oauth-client-jetty/pom.xml
+++ b/google-oauth-client-jetty/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.oauth-client</groupId>
     <artifactId>google-oauth-client-parent</artifactId>
-    <version>1.29.1-SNAPSHOT</version><!-- {x-version-update:google-oauth-client:current} -->
+    <version>1.30.0</version><!-- {x-version-update:google-oauth-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-oauth-client-jetty</artifactId>

--- a/google-oauth-client-servlet/pom.xml
+++ b/google-oauth-client-servlet/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.oauth-client</groupId>
     <artifactId>google-oauth-client-parent</artifactId>
-    <version>1.29.1-SNAPSHOT</version><!-- {x-version-update:google-oauth-client:current} -->
+    <version>1.30.0</version><!-- {x-version-update:google-oauth-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-oauth-client-servlet</artifactId>

--- a/google-oauth-client/pom.xml
+++ b/google-oauth-client/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.oauth-client</groupId>
     <artifactId>google-oauth-client-parent</artifactId>
-    <version>1.29.1-SNAPSHOT</version><!-- {x-version-update:google-oauth-client:current} -->
+    <version>1.30.0</version><!-- {x-version-update:google-oauth-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-oauth-client</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
   <groupId>com.google.oauth-client</groupId>
   <artifactId>google-oauth-client-parent</artifactId>
-  <version>1.29.1-SNAPSHOT</version><!-- {x-version-update:google-oauth-client:current} -->
+  <version>1.30.0</version><!-- {x-version-update:google-oauth-client:current} -->
   <packaging>pom</packaging>
   <name>Parent for the Google OAuth Client Library for Java</name>
 

--- a/samples/dailymotion-cmdline-sample/pom.xml
+++ b/samples/dailymotion-cmdline-sample/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.oauth-client</groupId>
     <artifactId>google-oauth-client-parent</artifactId>
-    <version>1.29.1-SNAPSHOT</version><!-- {x-version-update:google-oauth-client:current} -->
+    <version>1.30.0</version><!-- {x-version-update:google-oauth-client:current} -->
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>dailymotion-simple-cmdline-sample</artifactId>

--- a/versions.txt
+++ b/versions.txt
@@ -1,4 +1,4 @@
 # Format:
 # module:released-version:current-version
 
-google-oauth-client:1.29.0:1.29.1-SNAPSHOT
+google-oauth-client:1.30.0:1.30.0


### PR DESCRIPTION
This pull request was generated using releasetool.

06-05-2019 16:21 PDT

### Implementation Changes
- Convert from google-http-client-jackson to google-http-client-jackson2 ([#302](https://github.com/google/google-oauth-java-client/pull/302))

### Dependencies
- Update dependency com.google.http-client:google-http-client to v1.30.0 ([#299](https://github.com/google/google-oauth-java-client/pull/299))
- Update dependency com.google.http-client:google-http-client to v1.29.2 ([#289](https://github.com/google/google-oauth-java-client/pull/289))
- Update dependency org.datanucleus:datanucleus-rdbms to v3.2.13 ([#278](https://github.com/google/google-oauth-java-client/pull/278))
- Update dependency org.codehaus.mojo:findbugs-maven-plugin to v3 ([#283](https://github.com/google/google-oauth-java-client/pull/283))
- Update dependency org.apache.maven.plugins:maven-source-plugin to v3 ([#282](https://github.com/google/google-oauth-java-client/pull/282))
- Update dependency mysql:mysql-connector-java to v8 ([#280](https://github.com/google/google-oauth-java-client/pull/280))
- Update dependency org.sonatype.plugins:nexus-staging-maven-plugin to v1.6.8 ([#279](https://github.com/google/google-oauth-java-client/pull/279))
- Update dependency org.codehaus.mojo:findbugs-maven-plugin to v2.5.5 ([#274](https://github.com/google/google-oauth-java-client/pull/274))
- Update dependency org.codehaus.mojo:exec-maven-plugin to v1.6.0 ([#273](https://github.com/google/google-oauth-java-client/pull/273))
- Update dependency org.datanucleus:datanucleus-maven-plugin to v4.0.5 ([#277](https://github.com/google/google-oauth-java-client/pull/277))
- Update dependency org.apache.maven.plugins:maven-source-plugin to v2.4 ([#271](https://github.com/google/google-oauth-java-client/pull/271))
- Update dependency org.apache.maven.plugins:maven-deploy-plugin to v2.8.2 ([#269](https://github.com/google/google-oauth-java-client/pull/269))
- Update dependency org.apache.maven.plugins:maven-jar-plugin to v3.1.2 ([#270](https://github.com/google/google-oauth-java-client/pull/270))
- Update dependency junit:junit to v4.12 ([#267](https://github.com/google/google-oauth-java-client/pull/267))
- Update dependency mysql:mysql-connector-java to v5.1.47 ([#268](https://github.com/google/google-oauth-java-client/pull/268))
- Update dependency commons-codec:commons-codec to v1.12 ([#265](https://github.com/google/google-oauth-java-client/pull/265))
- Add renovate.json ([#260](https://github.com/google/google-oauth-java-client/pull/260))

### Internal / Testing Changes
- Bump next snapshot ([#259](https://github.com/google/google-oauth-java-client/pull/259))