### PR TITLE
Release google-oauth-java-client v1.30.1

### DIFF
--- a/google-oauth-client-appengine/pom.xml
+++ b/google-oauth-client-appengine/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.oauth-client</groupId>
     <artifactId>google-oauth-client-parent</artifactId>
-    <version>1.30.1-SNAPSHOT</version><!-- {x-version-update:google-oauth-client:current} -->
+    <version>1.30.1</version><!-- {x-version-update:google-oauth-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-oauth-client-appengine</artifactId>

--- a/google-oauth-client-assembly/pom.xml
+++ b/google-oauth-client-assembly/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.oauth-client</groupId>
     <artifactId>google-oauth-client-parent</artifactId>
-    <version>1.30.1-SNAPSHOT</version><!-- {x-version-update:google-oauth-client:current} -->
+    <version>1.30.1</version><!-- {x-version-update:google-oauth-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <groupId>com.google.oauth-client</groupId>

--- a/google-oauth-client-bom/README.md
+++ b/google-oauth-client-bom/README.md
@@ -12,7 +12,7 @@ To use it in Maven, add the following to your `pom.xml`:
     <dependency>
       <groupId>com.google.oauth-client</groupId>
       <artifactId>google-oauth-client-bom</artifactId>
-      <version>1.30.0</version>
+      <version>1.30.1</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>

--- a/google-oauth-client-bom/pom.xml
+++ b/google-oauth-client-bom/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.oauth-client</groupId>
   <artifactId>google-oauth-client-bom</artifactId>
-  <version>1.30.1-SNAPSHOT</version><!-- {x-version-update:google-oauth-client:current} -->
+  <version>1.30.1</version><!-- {x-version-update:google-oauth-client:current} -->
   <packaging>pom</packaging>
 
   <name>Google OAuth Client Library for Java BOM</name>
@@ -63,32 +63,32 @@
       <dependency>
         <groupId>com.google.oauth-client</groupId>
         <artifactId>google-oauth-client</artifactId>
-        <version>1.30.1-SNAPSHOT</version><!-- {x-version-update:google-oauth-client:current} -->
+        <version>1.30.1</version><!-- {x-version-update:google-oauth-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.oauth-client</groupId>
         <artifactId>google-oauth-client-appengine</artifactId>
-        <version>1.30.1-SNAPSHOT</version><!-- {x-version-update:google-oauth-client:current} -->
+        <version>1.30.1</version><!-- {x-version-update:google-oauth-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.oauth-client</groupId>
         <artifactId>google-oauth-client-assembly</artifactId>
-        <version>1.30.1-SNAPSHOT</version><!-- {x-version-update:google-oauth-client:current} -->
+        <version>1.30.1</version><!-- {x-version-update:google-oauth-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.oauth-client</groupId>
         <artifactId>google-oauth-client-java6</artifactId>
-        <version>1.30.1-SNAPSHOT</version><!-- {x-version-update:google-oauth-client:current} -->
+        <version>1.30.1</version><!-- {x-version-update:google-oauth-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.oauth-client</groupId>
         <artifactId>google-oauth-client-jetty</artifactId>
-        <version>1.30.1-SNAPSHOT</version><!-- {x-version-update:google-oauth-client:current} -->
+        <version>1.30.1</version><!-- {x-version-update:google-oauth-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.oauth-client</groupId>
         <artifactId>google-oauth-client-servlet</artifactId>
-        <version>1.30.1-SNAPSHOT</version><!-- {x-version-update:google-oauth-client:current} -->
+        <version>1.30.1</version><!-- {x-version-update:google-oauth-client:current} -->
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/google-oauth-client-java6/pom.xml
+++ b/google-oauth-client-java6/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.oauth-client</groupId>
     <artifactId>google-oauth-client-parent</artifactId>
-    <version>1.30.1-SNAPSHOT</version><!-- {x-version-update:google-oauth-client:current} -->
+    <version>1.30.1</version><!-- {x-version-update:google-oauth-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-oauth-client-java6</artifactId>

--- a/google-oauth-client-jetty/pom.xml
+++ b/google-oauth-client-jetty/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.oauth-client</groupId>
     <artifactId>google-oauth-client-parent</artifactId>
-    <version>1.30.1-SNAPSHOT</version><!-- {x-version-update:google-oauth-client:current} -->
+    <version>1.30.1</version><!-- {x-version-update:google-oauth-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-oauth-client-jetty</artifactId>

--- a/google-oauth-client-servlet/pom.xml
+++ b/google-oauth-client-servlet/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.oauth-client</groupId>
     <artifactId>google-oauth-client-parent</artifactId>
-    <version>1.30.1-SNAPSHOT</version><!-- {x-version-update:google-oauth-client:current} -->
+    <version>1.30.1</version><!-- {x-version-update:google-oauth-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-oauth-client-servlet</artifactId>

--- a/google-oauth-client/pom.xml
+++ b/google-oauth-client/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.oauth-client</groupId>
     <artifactId>google-oauth-client-parent</artifactId>
-    <version>1.30.1-SNAPSHOT</version><!-- {x-version-update:google-oauth-client:current} -->
+    <version>1.30.1</version><!-- {x-version-update:google-oauth-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-oauth-client</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
   <groupId>com.google.oauth-client</groupId>
   <artifactId>google-oauth-client-parent</artifactId>
-  <version>1.30.1-SNAPSHOT</version><!-- {x-version-update:google-oauth-client:current} -->
+  <version>1.30.1</version><!-- {x-version-update:google-oauth-client:current} -->
   <packaging>pom</packaging>
   <name>Parent for the Google OAuth Client Library for Java</name>
 

--- a/samples/dailymotion-cmdline-sample/pom.xml
+++ b/samples/dailymotion-cmdline-sample/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.oauth-client</groupId>
     <artifactId>google-oauth-client-parent</artifactId>
-    <version>1.30.1-SNAPSHOT</version><!-- {x-version-update:google-oauth-client:current} -->
+    <version>1.30.1</version><!-- {x-version-update:google-oauth-client:current} -->
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>dailymotion-simple-cmdline-sample</artifactId>

--- a/versions.txt
+++ b/versions.txt
@@ -1,4 +1,4 @@
 # Format:
 # module:released-version:current-version
 
-google-oauth-client:1.30.0:1.30.1-SNAPSHOT
+google-oauth-client:1.30.1:1.30.1


### PR DESCRIPTION
This pull request was generated using releasetool.

06-06-2019 14:37 PDT

### Dependencies
- Update dependency com.google.http-client:google-http-client to v1.30.1 ([#306](https://github.com/google/google-oauth-java-client/pull/306))
- Import google-http-client-bom for dependency management ([#301](https://github.com/google/google-oauth-java-client/pull/301))

### Internal / Testing Changes
- Enable autorelease ([#309](https://github.com/google/google-oauth-java-client/pull/309))
- Bump next snapshot ([#305](https://github.com/google/google-oauth-java-client/pull/305))