### PR TITLE
Update OAuthCredentialsResponse.java

### DIFF
--- a/google-oauth-client/src/main/java/com/google/api/client/auth/oauth/OAuthCredentialsResponse.java
+++ b/google-oauth-client/src/main/java/com/google/api/client/auth/oauth/OAuthCredentialsResponse.java
@@ -25,7 +25,7 @@ import com.google.api.client.util.Key;
  * @author Yaniv Inbar
  */
 @Beta
-public final class OAuthCredentialsResponse {
+public final class OAuthCredentialsResponse extends HashMap<String, Object> {
 
   /** Credentials token. */
   @Key("oauth_token")


### PR DESCRIPTION
Extending HashMap allows any ancillary response values provided by the service endpoint to be retrieved from the credential response.

Fixes #325 (it's a good idea to open an issue first for discussion)

- [ ] Tests pass
- [ ] Appropriate docs were updated (if necessary)
