### PR TITLE
feat: Added HMAC-SHA256 signature method in OAuthHmacSha256Signer

### DIFF
--- a/google-oauth-client/src/main/java/com/google/api/client/auth/oauth/OAuthHmacSha256Signer.java
+++ b/google-oauth-client/src/main/java/com/google/api/client/auth/oauth/OAuthHmacSha256Signer.java
@@ -24,13 +24,10 @@ import javax.crypto.spec.SecretKeySpec;
 
 /**
  * {@link Beta} <br>
- * OAuth {@code "HMAC-SHA1"} signature method.
- *
- * @since 1.0
- * @author Yaniv Inbar
+ * OAuth {@code "HMAC-SHA256"} signature method.
  */
 @Beta
-public final class OAuthHmacSigner implements OAuthSigner {
+public final class OAuthHmacSha256Signer implements OAuthSigner {
 
   /** Client-shared secret or {@code null} for none. */
   public String clientSharedSecret;
@@ -39,7 +36,7 @@ public final class OAuthHmacSigner implements OAuthSigner {
   public String tokenSharedSecret;
 
   public String getSignatureMethod() {
-    return "HMAC-SHA1";
+    return "HMAC-SHA256";
   }
 
   public String computeSignature(String signatureBaseString) throws GeneralSecurityException {
@@ -56,8 +53,8 @@ public final class OAuthHmacSigner implements OAuthSigner {
     }
     String key = keyBuf.toString();
     // sign
-    SecretKey secretKey = new SecretKeySpec(StringUtils.getBytesUtf8(key), "HmacSHA1");
-    Mac mac = Mac.getInstance("HmacSHA1");
+    SecretKey secretKey = new SecretKeySpec(StringUtils.getBytesUtf8(key), "HmacSHA256");
+    Mac mac = Mac.getInstance("HmacSHA256");
     mac.init(secretKey);
     return Base64.encodeBase64String(mac.doFinal(StringUtils.getBytesUtf8(signatureBaseString)));
   }

--- a/google-oauth-client/src/main/java/com/google/api/client/auth/oauth/OAuthHmacSha256Signer.java
+++ b/google-oauth-client/src/main/java/com/google/api/client/auth/oauth/OAuthHmacSha256Signer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010 Google Inc.
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -41,17 +41,17 @@ public final class OAuthHmacSha256Signer implements OAuthSigner {
 
   public String computeSignature(String signatureBaseString) throws GeneralSecurityException {
     // compute key
-    StringBuilder keyBuf = new StringBuilder();
+    StringBuilder keyBuffer = new StringBuilder();
     String clientSharedSecret = this.clientSharedSecret;
     if (clientSharedSecret != null) {
-      keyBuf.append(OAuthParameters.escape(clientSharedSecret));
+      keyBuffer.append(OAuthParameters.escape(clientSharedSecret));
     }
-    keyBuf.append('&');
+    keyBuffer.append('&');
     String tokenSharedSecret = this.tokenSharedSecret;
     if (tokenSharedSecret != null) {
-      keyBuf.append(OAuthParameters.escape(tokenSharedSecret));
+      keyBuffer.append(OAuthParameters.escape(tokenSharedSecret));
     }
-    String key = keyBuf.toString();
+    String key = keyBuffer.toString();
     // sign
     SecretKey secretKey = new SecretKeySpec(StringUtils.getBytesUtf8(key), "HmacSHA256");
     Mac mac = Mac.getInstance("HmacSHA256");

--- a/google-oauth-client/src/main/java/com/google/api/client/auth/oauth/OAuthHmacSha256Signer.java
+++ b/google-oauth-client/src/main/java/com/google/api/client/auth/oauth/OAuthHmacSha256Signer.java
@@ -23,41 +23,40 @@ import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 
 /**
- * {@link Beta} <br>
  * OAuth {@code "HMAC-SHA256"} signature method.
  */
 @Beta
 public final class OAuthHmacSha256Signer implements OAuthSigner {
 
   /** Client secret */
-  private String clientSharedSecret;
+  private final String clientSharedSecret;
 
   /** Token secret */
   private String tokenSharedSecret;
-
-  public void setClientSecret(String clientSecret) {
-    clientSharedSecret = clientSecret;
-  }
 
   public void setTokenSecret(String tokenSecret) {
     tokenSharedSecret = tokenSecret;
   }
 
+  public OAuthHmacSha256Signer(String clientSecret) {
+    this.clientSharedSecret = clientSecret;
+  }
+
+  @Override
   public String getSignatureMethod() {
     return "HMAC-SHA256";
   }
 
+  @Override
   public String computeSignature(String signatureBaseString) throws GeneralSecurityException {
     // compute key
     StringBuilder keyBuffer = new StringBuilder();
-    String clientSecret = clientSharedSecret;
-    if (clientSecret != null) {
-      keyBuffer.append(OAuthParameters.escape(clientSecret));
+    if (clientSharedSecret != null) {
+      keyBuffer.append(OAuthParameters.escape(clientSharedSecret));
     }
     keyBuffer.append('&');
-    String tokenSecret = tokenSharedSecret;
-    if (tokenSecret != null) {
-      keyBuffer.append(OAuthParameters.escape(tokenSecret));
+    if (tokenSharedSecret != null) {
+      keyBuffer.append(OAuthParameters.escape(tokenSharedSecret));
     }
     String key = keyBuffer.toString();
     // sign

--- a/google-oauth-client/src/main/java/com/google/api/client/auth/oauth/OAuthHmacSha256Signer.java
+++ b/google-oauth-client/src/main/java/com/google/api/client/auth/oauth/OAuthHmacSha256Signer.java
@@ -29,11 +29,19 @@ import javax.crypto.spec.SecretKeySpec;
 @Beta
 public final class OAuthHmacSha256Signer implements OAuthSigner {
 
-  /** Client-shared secret or {@code null} for none. */
-  public String clientSharedSecret;
+  /** Client secret */
+  private String clientSharedSecret;
 
-  /** Token-shared secret or {@code null} for none. */
-  public String tokenSharedSecret;
+  /** Token secret */
+  private String tokenSharedSecret;
+
+  public void setClientSecret(String clientSecret) {
+    clientSharedSecret = clientSecret;
+  }
+
+  public void setTokenSecret(String tokenSecret) {
+    tokenSharedSecret = tokenSecret;
+  }
 
   public String getSignatureMethod() {
     return "HMAC-SHA256";
@@ -42,14 +50,14 @@ public final class OAuthHmacSha256Signer implements OAuthSigner {
   public String computeSignature(String signatureBaseString) throws GeneralSecurityException {
     // compute key
     StringBuilder keyBuffer = new StringBuilder();
-    String clientSharedSecret = this.clientSharedSecret;
-    if (clientSharedSecret != null) {
-      keyBuffer.append(OAuthParameters.escape(clientSharedSecret));
+    String clientSecret = clientSharedSecret;
+    if (clientSecret != null) {
+      keyBuffer.append(OAuthParameters.escape(clientSecret));
     }
     keyBuffer.append('&');
-    String tokenSharedSecret = this.tokenSharedSecret;
-    if (tokenSharedSecret != null) {
-      keyBuffer.append(OAuthParameters.escape(tokenSharedSecret));
+    String tokenSecret = tokenSharedSecret;
+    if (tokenSecret != null) {
+      keyBuffer.append(OAuthParameters.escape(tokenSecret));
     }
     String key = keyBuffer.toString();
     // sign

--- a/google-oauth-client/src/main/java/com/google/api/client/auth/oauth/OAuthHmacSigner.java
+++ b/google-oauth-client/src/main/java/com/google/api/client/auth/oauth/OAuthHmacSigner.java
@@ -17,7 +17,7 @@ package com.google.api.client.auth.oauth;
 import com.google.api.client.util.Base64;
 import com.google.api.client.util.Beta;
 import com.google.api.client.util.StringUtils;
-import com.google.common.collect.ImmutableMap;
+
 import java.security.GeneralSecurityException;
 import java.util.Map;
 import javax.crypto.Mac;
@@ -55,6 +55,7 @@ public final class OAuthHmacSigner implements OAuthSigner {
     return signatureMethod;
   }
 
+  /** Set the signature method.  Valid signature methods are "HMAC-SHA1" and "HMAC-SHA256" */
   public void setSignatureMethod(String signatureMethod) throws IllegalArgumentException {
     if (signatureMethodMap.containsKey(signatureMethod)) {
       this.signatureMethod = signatureMethod;

--- a/google-oauth-client/src/main/java/com/google/api/client/auth/oauth/OAuthHmacSigner.java
+++ b/google-oauth-client/src/main/java/com/google/api/client/auth/oauth/OAuthHmacSigner.java
@@ -17,7 +17,7 @@ package com.google.api.client.auth.oauth;
 import com.google.api.client.util.Base64;
 import com.google.api.client.util.Beta;
 import com.google.api.client.util.StringUtils;
-
+import com.google.common.collect.ImmutableMap;
 import java.security.GeneralSecurityException;
 import java.util.Map;
 import javax.crypto.Mac;

--- a/google-oauth-client/src/main/java/com/google/api/client/auth/oauth/OAuthHmacSigner.java
+++ b/google-oauth-client/src/main/java/com/google/api/client/auth/oauth/OAuthHmacSigner.java
@@ -26,7 +26,7 @@ import javax.crypto.spec.SecretKeySpec;
 
 /**
  * {@link Beta} <br>
- * OAuth {@code "HMAC-SHA1"} signature method.
+ * OAuth {@code "HMAC-SHA1"} and {@code "HMAC-SHA256"} signature method.
  *
  * @since 1.0
  * @author Yaniv Inbar

--- a/google-oauth-client/src/test/java/com/google/api/client/auth/oauth/OAuthHmacSha256SignerTest.java
+++ b/google-oauth-client/src/test/java/com/google/api/client/auth/oauth/OAuthHmacSha256SignerTest.java
@@ -18,18 +18,16 @@ import java.security.GeneralSecurityException;
 import junit.framework.TestCase;
 
 /**
- * Tests {@link OAuthHmacSigner}.
- *
- * @author Yaniv Inbar
+ * Tests {@link OAuthHmacSha256Signer}.
  */
-public class OAuthHmacSignerTest extends TestCase {
+public class OAuthHmacSha256SignerTest extends TestCase {
 
-  private static final String EXPECTED_SIGNATURE = "0anl6O7gtZfslLZ5j3QoTwd0uPY=";
+  private static final String EXPECTED_SIGNATURE = "xDJIQbKJTwGumZFvSG1V3ctym2tz6kD8fKGWPr5ImPU=";
 
   public void testComputeSignature() throws GeneralSecurityException {
-    OAuthHmacSigner signer = new OAuthHmacSigner();
-    signer.clientSharedSecret = "abc";
-    signer.tokenSharedSecret = "def";
-    assertEquals(EXPECTED_SIGNATURE, signer.computeSignature("foo"));
+    OAuthHmacSha256Signer signer = new OAuthHmacSha256Signer();
+    signer.clientSharedSecret = "apiSecret";
+    signer.tokenSharedSecret = "tokenSecret";
+    assertEquals(EXPECTED_SIGNATURE, signer.computeSignature("baseString"));
   }
 }

--- a/google-oauth-client/src/test/java/com/google/api/client/auth/oauth/OAuthHmacSha256SignerTest.java
+++ b/google-oauth-client/src/test/java/com/google/api/client/auth/oauth/OAuthHmacSha256SignerTest.java
@@ -24,13 +24,33 @@ import static org.junit.Assert.assertEquals;
  */
 public class OAuthHmacSha256SignerTest {
 
-  private static final String EXPECTED_SIGNATURE = "xDJIQbKJTwGumZFvSG1V3ctym2tz6kD8fKGWPr5ImPU=";
+  @Test
+  public void testComputeSignatureWithNullSecrets() throws GeneralSecurityException {
+    OAuthHmacSha256Signer signer = new OAuthHmacSha256Signer(null);
+    String expectedSignature = "l/Es58FI4BtBciSH9XtY/5jXFee70v7/rPiQgEpvv00=";
+    assertEquals(expectedSignature, signer.computeSignature("baseString"));
+  }
+
+  @Test
+  public void testComputeSignatureWithNullClientSecret() throws GeneralSecurityException {
+    OAuthHmacSha256Signer signer = new OAuthHmacSha256Signer(null);
+    signer.setTokenSecret("tokenSecret");
+    String expectedSignature = "PgNWY2qQ53qvk3WySct/f037/usxMGpNDjmJeISmgCM=";
+    assertEquals(expectedSignature, signer.computeSignature("baseString"));
+  }
+
+  @Test
+  public void testComputeSignatureWithNullTokenSecret() throws GeneralSecurityException {
+    OAuthHmacSha256Signer signer = new OAuthHmacSha256Signer("clientSecret");
+    String expectedSignature = "cNrT2sqgyQ+dd7rbAhYBFBk8o82/yZyZkavqsfMDqpo=";
+    assertEquals(expectedSignature, signer.computeSignature("baseString"));
+  }
 
   @Test
   public void testComputeSignature() throws GeneralSecurityException {
-    OAuthHmacSha256Signer signer = new OAuthHmacSha256Signer();
-    signer.setClientSecret("apiSecret");
+    OAuthHmacSha256Signer signer = new OAuthHmacSha256Signer("clientSecret");
     signer.setTokenSecret("tokenSecret");
-    assertEquals(EXPECTED_SIGNATURE, signer.computeSignature("baseString"));
+    String expectedSignature = "sfnrBcfwccOs2mpc60VQ5zXx5ReP/46lgUcBhU2a4PM=";
+    assertEquals(expectedSignature, signer.computeSignature("baseString"));
   }
 }

--- a/google-oauth-client/src/test/java/com/google/api/client/auth/oauth/OAuthHmacSha256SignerTest.java
+++ b/google-oauth-client/src/test/java/com/google/api/client/auth/oauth/OAuthHmacSha256SignerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 Google Inc.
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/google-oauth-client/src/test/java/com/google/api/client/auth/oauth/OAuthHmacSha256SignerTest.java
+++ b/google-oauth-client/src/test/java/com/google/api/client/auth/oauth/OAuthHmacSha256SignerTest.java
@@ -15,19 +15,22 @@
 package com.google.api.client.auth.oauth;
 
 import java.security.GeneralSecurityException;
-import junit.framework.TestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Tests {@link OAuthHmacSha256Signer}.
  */
-public class OAuthHmacSha256SignerTest extends TestCase {
+public class OAuthHmacSha256SignerTest {
 
   private static final String EXPECTED_SIGNATURE = "xDJIQbKJTwGumZFvSG1V3ctym2tz6kD8fKGWPr5ImPU=";
 
+  @Test
   public void testComputeSignature() throws GeneralSecurityException {
     OAuthHmacSha256Signer signer = new OAuthHmacSha256Signer();
-    signer.clientSharedSecret = "apiSecret";
-    signer.tokenSharedSecret = "tokenSecret";
+    signer.setClientSecret("apiSecret");
+    signer.setTokenSecret("tokenSecret");
     assertEquals(EXPECTED_SIGNATURE, signer.computeSignature("baseString"));
   }
 }

--- a/google-oauth-client/src/test/java/com/google/api/client/auth/oauth/OAuthHmacSignerTest.java
+++ b/google-oauth-client/src/test/java/com/google/api/client/auth/oauth/OAuthHmacSignerTest.java
@@ -16,6 +16,9 @@ package com.google.api.client.auth.oauth;
 
 import java.security.GeneralSecurityException;
 import junit.framework.TestCase;
+import org.junit.function.ThrowingRunnable;
+
+import static org.junit.Assert.assertThrows;
 
 /**
  * Tests {@link OAuthHmacSigner}.
@@ -31,5 +34,40 @@ public class OAuthHmacSignerTest extends TestCase {
     signer.clientSharedSecret = "abc";
     signer.tokenSharedSecret = "def";
     assertEquals(EXPECTED_SIGNATURE, signer.computeSignature("foo"));
+  }
+
+  public void testComputeSignatureHmacSha256() throws GeneralSecurityException {
+    final OAuthHmacSigner signer = new OAuthHmacSigner();
+    signer.setSignatureMethod("HMAC-SHA256");
+    signer.clientSharedSecret = "apiSecret";
+    signer.tokenSharedSecret = "tokenSecret";
+    final String expected = "xDJIQbKJTwGumZFvSG1V3ctym2tz6kD8fKGWPr5ImPU=";
+    assertEquals(expected, signer.computeSignature("baseString"));
+  }
+
+  public void testGetSignatureMethod() {
+    final OAuthHmacSigner signer = new OAuthHmacSigner();
+    final String expected = "HMAC-SHA1";
+    assertEquals(expected, signer.getSignatureMethod());
+  }
+
+  public void testGetSignatureMethodHmacSha256() {
+    final OAuthHmacSigner signer = new OAuthHmacSigner();
+    final String signatureMethod = "HMAC-SHA256";
+    signer.setSignatureMethod(signatureMethod);
+    assertEquals(signatureMethod, signer.getSignatureMethod());
+  }
+
+  public void testSetSignatureMethodHmacMD5() {
+    assertThrows(
+            "Signature method HMAC-MD5 not available",
+            IllegalArgumentException.class,
+            new ThrowingRunnable() {
+              @Override
+              public void run() {
+                new OAuthHmacSigner().setSignatureMethod("HMAC-MD5");
+              }
+            }
+    );
   }
 }


### PR DESCRIPTION
I have added OAuthHmacSha256Signer to enable using the signature method to HMAC-SHA256.

Unit test/code coverage has been added in OAuthHmacSha256SignerTest.

This change is necessary for establishing connections to NetSuite as they will no longer accept HMAC-SHA1 as a signature method.

Fixes #702  ☕️

This pull request should be close and replaced by #711.  There were issues with the original commit email, and I was unable to resolve them by rebasing (a few of the commits did not get rebased correctly).