### PR TITLE
feat: Add HMAC-SHA256 signature method for OAuth 1.0

### DIFF
--- a/google-oauth-client/src/main/java/com/google/api/client/auth/oauth/OAuthHmacSha256Signer.java
+++ b/google-oauth-client/src/main/java/com/google/api/client/auth/oauth/OAuthHmacSha256Signer.java
@@ -16,15 +16,12 @@ package com.google.api.client.auth.oauth;
 
 import com.google.api.client.util.StringUtils;
 import com.google.common.io.BaseEncoding;
-
 import java.security.GeneralSecurityException;
 import javax.crypto.Mac;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 
-/**
- * OAuth {@code "HMAC-SHA256"} signature method.
- */
+/** OAuth {@code "HMAC-SHA256"} signature method. */
 public final class OAuthHmacSha256Signer implements OAuthSigner {
 
   /** Client secret */

--- a/google-oauth-client/src/main/java/com/google/api/client/auth/oauth/OAuthHmacSha256Signer.java
+++ b/google-oauth-client/src/main/java/com/google/api/client/auth/oauth/OAuthHmacSha256Signer.java
@@ -14,9 +14,9 @@
 
 package com.google.api.client.auth.oauth;
 
-import com.google.api.client.util.Base64;
-import com.google.api.client.util.Beta;
 import com.google.api.client.util.StringUtils;
+import com.google.common.io.BaseEncoding;
+
 import java.security.GeneralSecurityException;
 import javax.crypto.Mac;
 import javax.crypto.SecretKey;
@@ -25,7 +25,6 @@ import javax.crypto.spec.SecretKeySpec;
 /**
  * OAuth {@code "HMAC-SHA256"} signature method.
  */
-@Beta
 public final class OAuthHmacSha256Signer implements OAuthSigner {
 
   /** Client secret */
@@ -63,6 +62,6 @@ public final class OAuthHmacSha256Signer implements OAuthSigner {
     SecretKey secretKey = new SecretKeySpec(StringUtils.getBytesUtf8(key), "HmacSHA256");
     Mac mac = Mac.getInstance("HmacSHA256");
     mac.init(secretKey);
-    return Base64.encodeBase64String(mac.doFinal(StringUtils.getBytesUtf8(signatureBaseString)));
+    return BaseEncoding.base64().encode(mac.doFinal(StringUtils.getBytesUtf8(signatureBaseString)));
   }
 }

--- a/google-oauth-client/src/main/java/com/google/api/client/auth/oauth/OAuthHmacSha256Signer.java
+++ b/google-oauth-client/src/main/java/com/google/api/client/auth/oauth/OAuthHmacSha256Signer.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.api.client.auth.oauth;
+
+import com.google.api.client.util.Base64;
+import com.google.api.client.util.Beta;
+import com.google.api.client.util.StringUtils;
+import java.security.GeneralSecurityException;
+import javax.crypto.Mac;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+
+/**
+ * OAuth {@code "HMAC-SHA256"} signature method.
+ */
+@Beta
+public final class OAuthHmacSha256Signer implements OAuthSigner {
+
+  /** Client secret */
+  private final String clientSharedSecret;
+
+  /** Token secret */
+  private String tokenSharedSecret;
+
+  public void setTokenSecret(String tokenSecret) {
+    tokenSharedSecret = tokenSecret;
+  }
+
+  public OAuthHmacSha256Signer(String clientSecret) {
+    this.clientSharedSecret = clientSecret;
+  }
+
+  @Override
+  public String getSignatureMethod() {
+    return "HMAC-SHA256";
+  }
+
+  @Override
+  public String computeSignature(String signatureBaseString) throws GeneralSecurityException {
+    // compute key
+    StringBuilder keyBuffer = new StringBuilder();
+    if (clientSharedSecret != null) {
+      keyBuffer.append(OAuthParameters.escape(clientSharedSecret));
+    }
+    keyBuffer.append('&');
+    if (tokenSharedSecret != null) {
+      keyBuffer.append(OAuthParameters.escape(tokenSharedSecret));
+    }
+    String key = keyBuffer.toString();
+    // sign
+    SecretKey secretKey = new SecretKeySpec(StringUtils.getBytesUtf8(key), "HmacSHA256");
+    Mac mac = Mac.getInstance("HmacSHA256");
+    mac.init(secretKey);
+    return Base64.encodeBase64String(mac.doFinal(StringUtils.getBytesUtf8(signatureBaseString)));
+  }
+}

--- a/google-oauth-client/src/test/java/com/google/api/client/auth/oauth/OAuthHmacSha256SignerTest.java
+++ b/google-oauth-client/src/test/java/com/google/api/client/auth/oauth/OAuthHmacSha256SignerTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.api.client.auth.oauth;
+
+import java.security.GeneralSecurityException;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests {@link OAuthHmacSha256Signer}.
+ */
+public class OAuthHmacSha256SignerTest {
+
+  @Test
+  public void testComputeSignatureWithNullSecrets() throws GeneralSecurityException {
+    OAuthHmacSha256Signer signer = new OAuthHmacSha256Signer(null);
+    String expectedSignature = "l/Es58FI4BtBciSH9XtY/5jXFee70v7/rPiQgEpvv00=";
+    assertEquals(expectedSignature, signer.computeSignature("baseString"));
+  }
+
+  @Test
+  public void testComputeSignatureWithNullClientSecret() throws GeneralSecurityException {
+    OAuthHmacSha256Signer signer = new OAuthHmacSha256Signer(null);
+    signer.setTokenSecret("tokenSecret");
+    String expectedSignature = "PgNWY2qQ53qvk3WySct/f037/usxMGpNDjmJeISmgCM=";
+    assertEquals(expectedSignature, signer.computeSignature("baseString"));
+  }
+
+  @Test
+  public void testComputeSignatureWithNullTokenSecret() throws GeneralSecurityException {
+    OAuthHmacSha256Signer signer = new OAuthHmacSha256Signer("clientSecret");
+    String expectedSignature = "cNrT2sqgyQ+dd7rbAhYBFBk8o82/yZyZkavqsfMDqpo=";
+    assertEquals(expectedSignature, signer.computeSignature("baseString"));
+  }
+
+  @Test
+  public void testComputeSignature() throws GeneralSecurityException {
+    OAuthHmacSha256Signer signer = new OAuthHmacSha256Signer("clientSecret");
+    signer.setTokenSecret("tokenSecret");
+    String expectedSignature = "sfnrBcfwccOs2mpc60VQ5zXx5ReP/46lgUcBhU2a4PM=";
+    assertEquals(expectedSignature, signer.computeSignature("baseString"));
+  }
+}

--- a/google-oauth-client/src/test/java/com/google/api/client/auth/oauth/OAuthHmacSha256SignerTest.java
+++ b/google-oauth-client/src/test/java/com/google/api/client/auth/oauth/OAuthHmacSha256SignerTest.java
@@ -14,14 +14,12 @@
 
 package com.google.api.client.auth.oauth;
 
+import static org.junit.Assert.assertEquals;
+
 import java.security.GeneralSecurityException;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-
-/**
- * Tests {@link OAuthHmacSha256Signer}.
- */
+/** Tests {@link OAuthHmacSha256Signer}. */
 public class OAuthHmacSha256SignerTest {
 
   @Test


### PR DESCRIPTION
I have added OAuthHmacSha256Signer to enable using the signature method HMAC-SHA256.

Unit test/code coverage has been added in OAuthHmacSha256SignerTest.

This change is necessary for establishing connections to NetSuite as they will no longer accept HMAC-SHA1 as a signature method.

Fixes #702

This replaces pull request #703, which should be closed in favor of this one.  The code is the same (two of the four files modified in the original PR were reverted back to their original versions), so there are only two new files, one class and a test class.