### PR TITLE
ci: removing linkage-monitor from required checks

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -13,7 +13,6 @@ branchProtectionRules:
       - units (11)
       - dependencies (8)
       - dependencies (11)
-      - linkage-monitor
       - clirr
       - cla/google
   - pattern: 1.31.4-sp
@@ -27,7 +26,6 @@ branchProtectionRules:
       - units (11)
       - dependencies (8)
       - dependencies (11)
-      - linkage-monitor
       - clirr
       - cla/google
   - pattern: 1.32.x
@@ -41,7 +39,6 @@ branchProtectionRules:
       - units (11)
       - dependencies (8)
       - dependencies (11)
-      - linkage-monitor
       - clirr
       - cla/google
 permissionRules:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,19 +31,6 @@ jobs:
         java-version: ${{matrix.java}}
     - run: java -version
     - run: .kokoro/dependencies.sh
-  linkage-monitor:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-java@v1
-      with:
-        java-version: 8
-    - run: java -version
-    - name: Install artifacts to local Maven repository
-      run: .kokoro/build.sh
-      shell: bash
-    - name: Validate any conflicts with regard to com.google.cloud:libraries-bom (latest release)
-      uses: GoogleCloudPlatform/cloud-opensource-java/linkage-monitor@v1-linkagemonitor
   lint:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
We no longer use Linkage Monitor.