### PR TITLE
chore: downstream check for all libraries in single job

### DIFF
--- a/.github/workflows/downstream.yaml
+++ b/.github/workflows/downstream.yaml
@@ -13,6 +13,7 @@ jobs:
       matrix:
         java: [17]
         repo:
+        # This list needs to be updated manually until an automated solution is in place.
         - accessapproval
         - accesscontextmanager
         - aiplatform

--- a/.github/workflows/downstream.yaml
+++ b/.github/workflows/downstream.yaml
@@ -1,0 +1,141 @@
+on:
+  pull_request:
+    types: [ labeled ]
+    branches:
+    - main
+name: downstream
+jobs:
+  dependencies:
+    if: ${{ github.event.label.name == 'downstream-check:run' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [17]
+        repo:
+        - accessapproval
+        - accesscontextmanager
+        - aiplatform
+        - analytics-admin
+        - analytics-data
+        - api-gateway
+        - apigee-connect
+        - appengine-admin
+        - area120-tables
+        - artifact-registry
+        - asset
+        - assured-workloads
+        - automl
+        - bigquery
+        - bigqueryconnection
+        - bigquerydatatransfer
+        - bigquerymigration
+        - bigqueryreservation
+        - bigtable
+        - billing
+        - billingbudgets
+        - binary-authorization
+        - channel
+        - cloudbuild
+        - compute
+        - contact-center-insights
+        - container
+        - containeranalysis
+        - data-fusion
+        - datacatalog
+        - dataflow
+        - datalabeling
+        - dataproc
+        - dataproc-metastore
+        - datastore
+        - datastream
+        - debugger-client
+        - deploy
+        - dialogflow
+        - dialogflow-cx
+        - dlp
+        - dms
+        - dns
+        - document-ai
+        - domains
+        - errorreporting
+        - essential-contacts
+        - eventarc
+        - filestore
+        - firestore
+        - functions
+        - game-servers
+        - gke-connect-gateway
+        - gkehub
+        - gsuite-addons
+        - iam-admin
+        - iamcredentials
+        - iot
+        - kms
+        - language
+        - life-sciences
+        - logging
+        - logging-logback
+        - managed-identities
+        - mediatranslation
+        - memcache
+        - monitoring
+        - monitoring-dashboards
+        - network-management
+        - network-security
+        - networkconnectivity
+        - notebooks
+        - orchestration-airflow
+        - orgpolicy
+        - os-config
+        - os-login
+        - phishingprotection
+        - policy-troubleshooter
+        - private-catalog
+        - profiler
+        - pubsublite
+        - recaptchaenterprise
+        - recommendations-ai
+        - recommender
+        - redis
+        - resource-settings
+        - resourcemanager
+        - retail
+        - scheduler
+        - secretmanager
+        - security-private-ca
+        - securitycenter
+        - securitycenter-settings
+        - service-control
+        - service-management
+        - service-usage
+        - servicedirectory
+        - shell
+        - spanner
+        - spanner-jdbc
+        - speech
+        - storage
+        - storage-nio
+        - storage-transfer
+        - talent
+        - tasks
+        - texttospeech
+        - tpu
+        - trace
+        - translate
+        - video-intelligence
+        - video-transcoder
+        - vision
+        - vpcaccess
+        - webrisk
+        - websecurityscanner
+        - workflow-executions
+        - workflows
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-java@v1
+      with:
+        java-version: ${{matrix.java}}
+    - run: java -version
+    - run: sudo apt-get install libxml2-utils
+    - run: .kokoro/downstream-client-library-check.sh google-oauth-client-bom ${{matrix.repo}}

--- a/.kokoro/downstream-client-library-check.sh
+++ b/.kokoro/downstream-client-library-check.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail
+# Display commands being run.
+set -x
+
+
+CORE_LIBRARY_ARTIFACT=$1
+CLIENT_LIBRARY=$2
+## Get the directory of the build script
+scriptDir=$(realpath $(dirname "${BASH_SOURCE[0]}"))
+## cd to the parent directory, i.e. the root of the git repo
+cd ${scriptDir}/..
+
+# Make java core library artifacts available for 'mvn validate' at the bottom
+mvn install -DskipTests=true -Dmaven.javadoc.skip=true -Dgcloud.download.skip=true -B -V -q
+
+# Read the current version of this java core library in the POM. Example version: '0.116.1-alpha-SNAPSHOT'
+CORE_VERSION_POM=pom.xml
+# Namespace (xmlns) prevents xmllint from specifying tag names in XPath
+CORE_VERSION=`sed -e 's/xmlns=".*"//' ${CORE_VERSION_POM} | xmllint --xpath '/project/version/text()' -`
+
+if [ -z "${CORE_VERSION}" ]; then
+  echo "Version is not found in ${CORE_VERSION_POM}"
+  exit 1
+fi
+echo "Version: ${CORE_VERSION}"
+
+# Round 1
+# Check this java core library against HEAD of java-shared dependencies
+
+git clone "https://github.com/googleapis/java-shared-dependencies.git" --depth=1
+pushd java-shared-dependencies/first-party-dependencies
+
+# replace version
+xmllint --shell <(cat pom.xml) << EOF
+setns x=http://maven.apache.org/POM/4.0.0
+cd .//x:artifactId[text()="${CORE_LIBRARY_ARTIFACT}"]
+cd ../x:version
+set ${CORE_VERSION}
+save pom.xml
+EOF
+
+# run dependencies script
+cd ..
+mvn -Denforcer.skip=true clean install
+
+SHARED_DEPS_VERSION_POM=pom.xml
+# Namespace (xmlns) prevents xmllint from specifying tag names in XPath
+SHARED_DEPS_VERSION=`sed -e 's/xmlns=".*"//' ${SHARED_DEPS_VERSION_POM} | xmllint --xpath '/project/version/text()' -`
+
+if [ -z "${SHARED_DEPS_VERSION}" ]; then
+  echo "Version is not found in ${SHARED_DEPS_VERSION_POM}"
+  exit 1
+fi
+
+# Round 2
+
+# Check this BOM against java client libraries
+git clone "https://github.com/googleapis/java-${CLIENT_LIBRARY}.git" --depth=1
+pushd java-${CLIENT_LIBRARY}
+
+if [[ $CLIENT_LIBRARY == "bigtable" ]]; then
+  pushd google-cloud-bigtable-deps-bom
+fi
+
+# replace version
+xmllint --shell <(cat pom.xml) << EOF
+setns x=http://maven.apache.org/POM/4.0.0
+cd .//x:artifactId[text()="google-cloud-shared-dependencies"]
+cd ../x:version
+set ${SHARED_DEPS_VERSION}
+save pom.xml
+EOF
+
+if [[ $CLIENT_LIBRARY == "bigtable" ]]; then
+  popd
+fi
+
+mvn -Denforcer.skip=true clean install

--- a/.kokoro/downstream-client-library-check.sh
+++ b/.kokoro/downstream-client-library-check.sh
@@ -25,7 +25,7 @@ scriptDir=$(realpath $(dirname "${BASH_SOURCE[0]}"))
 ## cd to the parent directory, i.e. the root of the git repo
 cd ${scriptDir}/..
 
-# Make java core library artifacts available for 'mvn validate' at the bottom
+# Make java core library artifacts available for 'mvn verify' at the bottom
 mvn verify install -B -V -ntp -fae \
 -DskipTests=true \
 -Dmaven.javadoc.skip=true \

--- a/.kokoro/downstream-client-library-check.sh
+++ b/.kokoro/downstream-client-library-check.sh
@@ -21,9 +21,9 @@ set -x
 CORE_LIBRARY_ARTIFACT=$1
 CLIENT_LIBRARY=$2
 ## Get the directory of the build script
-scriptDir=$(realpath $(dirname "${BASH_SOURCE[0]}"))
+scriptDir="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
 ## cd to the parent directory, i.e. the root of the git repo
-cd ${scriptDir}/..
+cd "${scriptDir}"/..
 
 # Make java core library artifacts available for 'mvn verify' at the bottom
 mvn verify install -B -V -ntp -fae \
@@ -35,7 +35,7 @@ mvn verify install -B -V -ntp -fae \
 # Read the current version of this java core library in the POM. Example version: '0.116.1-alpha-SNAPSHOT'
 CORE_VERSION_POM=pom.xml
 # Namespace (xmlns) prevents xmllint from specifying tag names in XPath
-CORE_VERSION=`sed -e 's/xmlns=".*"//' ${CORE_VERSION_POM} | xmllint --xpath '/project/version/text()' -`
+CORE_VERSION=$(sed -e 's/xmlns=".*"//' ${CORE_VERSION_POM} | xmllint --xpath '/project/version/text()' -)
 
 if [ -z "${CORE_VERSION}" ]; then
   echo "Version is not found in ${CORE_VERSION_POM}"
@@ -68,7 +68,7 @@ mvn verify install -B -V -ntp -fae \
 
 SHARED_DEPS_VERSION_POM=pom.xml
 # Namespace (xmlns) prevents xmllint from specifying tag names in XPath
-SHARED_DEPS_VERSION=`sed -e 's/xmlns=".*"//' ${SHARED_DEPS_VERSION_POM} | xmllint --xpath '/project/version/text()' -`
+SHARED_DEPS_VERSION=$(sed -e 's/xmlns=".*"//' ${SHARED_DEPS_VERSION_POM} | xmllint --xpath '/project/version/text()' -)
 
 if [ -z "${SHARED_DEPS_VERSION}" ]; then
   echo "Version is not found in ${SHARED_DEPS_VERSION_POM}"
@@ -79,7 +79,7 @@ fi
 
 # Check this BOM against java client libraries
 git clone "https://github.com/googleapis/java-${CLIENT_LIBRARY}.git" --depth=1
-pushd java-${CLIENT_LIBRARY}
+pushd java-"${CLIENT_LIBRARY}"
 
 if [[ $CLIENT_LIBRARY == "bigtable" ]]; then
   pushd google-cloud-bigtable-deps-bom

--- a/.kokoro/downstream-client-library-check.sh
+++ b/.kokoro/downstream-client-library-check.sh
@@ -29,7 +29,8 @@ cd ${scriptDir}/..
 mvn verify install -B -V -ntp -fae \
 -DskipTests=true \
 -Dmaven.javadoc.skip=true \
--Dgcloud.download.skip=true
+-Dgcloud.download.skip=true \
+-Denforcer.skip=true
 
 # Read the current version of this java core library in the POM. Example version: '0.116.1-alpha-SNAPSHOT'
 CORE_VERSION_POM=pom.xml
@@ -62,7 +63,8 @@ cd ..
 mvn verify install -B -V -ntp -fae \
 -DskipTests=true \
 -Dmaven.javadoc.skip=true \
--Dgcloud.download.skip=true
+-Dgcloud.download.skip=true \
+-Denforcer.skip=true
 
 SHARED_DEPS_VERSION_POM=pom.xml
 # Namespace (xmlns) prevents xmllint from specifying tag names in XPath
@@ -98,4 +100,5 @@ fi
 
 mvn verify install -B -V -ntp -fae \
 -Dmaven.javadoc.skip=true \
--Dgcloud.download.skip=true
+-Dgcloud.download.skip=true \
+-Denforcer.skip=true

--- a/.kokoro/downstream-client-library-check.sh
+++ b/.kokoro/downstream-client-library-check.sh
@@ -26,7 +26,10 @@ scriptDir=$(realpath $(dirname "${BASH_SOURCE[0]}"))
 cd ${scriptDir}/..
 
 # Make java core library artifacts available for 'mvn validate' at the bottom
-mvn install -DskipTests=true -Dmaven.javadoc.skip=true -Dgcloud.download.skip=true -B -V -q
+mvn verify install -B -V -ntp -fae \
+-DskipTests=true \
+-Dmaven.javadoc.skip=true \
+-Dgcloud.download.skip=true
 
 # Read the current version of this java core library in the POM. Example version: '0.116.1-alpha-SNAPSHOT'
 CORE_VERSION_POM=pom.xml
@@ -56,7 +59,10 @@ EOF
 
 # run dependencies script
 cd ..
-mvn -Denforcer.skip=true clean install
+mvn verify install -B -V -ntp -fae \
+-DskipTests=true \
+-Dmaven.javadoc.skip=true \
+-Dgcloud.download.skip=true
 
 SHARED_DEPS_VERSION_POM=pom.xml
 # Namespace (xmlns) prevents xmllint from specifying tag names in XPath
@@ -90,4 +96,6 @@ if [[ $CLIENT_LIBRARY == "bigtable" ]]; then
   popd
 fi
 
-mvn -Denforcer.skip=true clean install
+mvn verify install -B -V -ntp -fae \
+-Dmaven.javadoc.skip=true \
+-Dgcloud.download.skip=true


### PR DESCRIPTION
Test core java libraries in java client libraries before release. Feature/code changes introduced in each PR can be tested on downstream java client libraries by adding `downstream-check:run` label. For now, unit tests are being run.

Next phase involves running samples and integration tests.

Note: Some of these tests are expected to fail due to individual client library conditions and do block the merging of this PR.