### PR TITLE
perf: drop off redundant dependencies

### DIFF
--- a/google-oauth-client/pom.xml
+++ b/google-oauth-client/pom.xml
@@ -78,6 +78,16 @@
     <dependency>
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>jsr305</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.j2objc</groupId>
+           <artifactId>j2objc-annotations</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.http-client</groupId>
@@ -92,6 +102,16 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>jsr305</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.j2objc</groupId>
+           <artifactId>j2objc-annotations</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
@yoshi-approver  Hi! I found the pom file of project **_com.google.oauth-client:google-oauth-client:1.33.2-SNAPSHOT_** introduced **_20_** dependencies. However, among them, **_5_** libraries (**_25%_**) are not used by your project. I list the redundant dependencies below (labelled as red ones in the figure):
## Redundant dependencies
com.google.code.findbugs:jsr305:jar:3.0.2:compile
com.google.errorprone:error_prone_annotations:jar:2.7.1:compile
com.google.guava:listenablefuture:jar:9999.0-empty-to-avoid-conflict-with-guava:compile
org.checkerframework:checker-compat-qual:jar:2.5.5:compile
com.google.j2objc:j2objc-annotations:jar:1.3:compile 

---
Removing the redundant dependencies can reduce the size of project and prevent potential dependency conflict issues (i.e., multiple versions of the same library). More importantly, 2 of the redundant dependencies **_com.google.code.findbugs:jsr305:jar:3.0.2:compile, com.google.j2objc:j2objc-annotations:jar:1.3:compile_** induced dependency conflict in the dependency graph. As such, I suggest a refactoring operation for **_com.google.oauth-client:google-oauth-client:1.33.2-SNAPSHOT_**’s pom file.

The attached PR helps resolve the reported problem. It is safe to remove the unused libraries (we considered Java reflection relations when analyzing the dependencies). These changes have passed **_com.google.oauth-client:google-oauth-client:1.33.2-SNAPSHOT_**’s maven tests.

Best regards

![image](https://user-images.githubusercontent.com/78527112/156759180-173e2ce2-0f23-4cd1-a906-de20b482b49e.png)
