### PR TITLE
chore: fix code formatting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -434,7 +434,7 @@
       <plugin>
         <groupId>com.coveo</groupId>
         <artifactId>fmt-maven-plugin</artifactId>
-        <version>2.13</version>
+        <version>2.9</version>
         <configuration>
           <style>google</style>
           <verbose>true</verbose>
@@ -443,7 +443,7 @@
           <dependency>
             <groupId>com.google.googlejavaformat</groupId>
             <artifactId>google-java-format</artifactId>
-            <version>1.15.0</version>
+            <version>1.7</version>
           </dependency>
         </dependencies>
       </plugin>


### PR DESCRIPTION
Updates the code formatter plugin to match what's in the google-cloud-shared-config. The post-processor seems to automatically run the code formatter, but the version needs to match or the test will not pass.

Related #1058 