### PR TITLE
chore: Update release-please versioning to "always-bump-minor"

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,6 +1,7 @@
 bumpMinorPreMajor: true
 handleGHRelease: true
 releaseType: java-yoshi
+versioning: always-bump-minor
 branches:
   - bumpMinorPreMajor: true
     handleGHRelease: true


### PR DESCRIPTION
This versioning strategy always only bumps the minor version irrespective of the changes committed.  We can remove this after the minor-version release and releases will fall back to default versioning strategy. 
Reference: https://github.com/googleapis/release-please/blob/main/docs/customizing.md#versioning-strategies

