### PR TITLE
fix: deprecating the IdTokenVerifier.verify, adding verifyOrThrow as an alternative

### DIFF
--- a/google-oauth-client/src/main/java/com/google/api/client/auth/openidconnect/IdTokenVerifier.java
+++ b/google-oauth-client/src/main/java/com/google/api/client/auth/openidconnect/IdTokenVerifier.java
@@ -227,9 +227,9 @@ public class IdTokenVerifier {
    *       variable set to true. Use {@link #verifyPayload(IdToken)} instead.
    * </ul>
    *
-   * Deprecated. This method returns false if network requests to get certificates fail. Use
-   * {@link IdTokenVerifier.verfyOrThrow(IdToken)} instead to differentiate between potentially
-   * retryable network errors and false verification results.
+   * Deprecated. This method returns false if network requests to get certificates fail. Use {@link
+   * IdTokenVerifier.verfyOrThrow(IdToken)} instead to differentiate between potentially retryable
+   * network errors and false verification results.
    *
    * @param idToken ID token
    * @return {@code true} if verified successfully or {@code false} if failed

--- a/google-oauth-client/src/main/java/com/google/api/client/auth/openidconnect/IdTokenVerifier.java
+++ b/google-oauth-client/src/main/java/com/google/api/client/auth/openidconnect/IdTokenVerifier.java
@@ -25,7 +25,6 @@ import com.google.api.client.json.GenericJson;
 import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.client.json.webtoken.JsonWebSignature.Header;
 import com.google.api.client.util.Base64;
-import com.google.api.client.util.Beta;
 import com.google.api.client.util.Clock;
 import com.google.api.client.util.ExponentialBackOff;
 import com.google.api.client.util.Key;
@@ -66,7 +65,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * {@link Beta} <br>
  * Thread-safe ID token verifier based on <a
  * href="http://openid.net/specs/openid-connect-basic-1_0-27.html#id.token.validation">ID Token
  * Validation</a>.
@@ -110,7 +108,6 @@ import java.util.logging.Logger;
  *
  * @since 1.16
  */
-@Beta
 public class IdTokenVerifier {
   private static final Logger LOGGER = Logger.getLogger(IdTokenVerifier.class.getName());
   private static final String IAP_CERT_URL = "https://www.gstatic.com/iap/verify/public_key-jwk";
@@ -230,7 +227,7 @@ public class IdTokenVerifier {
    *       variable set to true.
    * </ul>
    *
-   * Deprecated, because can return false-negatives if there was an error while getting public keys
+   * Deprecated, because returns a false-negatives in case of an error while getting public keys
    * for signature verification. Use {@link IdTokenVerifier.verfyOrThrow(IdToken)} instead.
    *
    * @param idToken ID token
@@ -284,8 +281,8 @@ public class IdTokenVerifier {
 
     try {
       return verifySignature(idToken);
-    } catch (VerificationException vex) {
-      LOGGER.log(Level.INFO, "Id token signature verification failed. ", vex);
+    } catch (VerificationException ex) {
+      LOGGER.log(Level.INFO, "Id token signature verification failed. ", ex);
       return false;
     }
   }

--- a/google-oauth-client/src/main/java/com/google/api/client/auth/openidconnect/IdTokenVerifier.java
+++ b/google-oauth-client/src/main/java/com/google/api/client/auth/openidconnect/IdTokenVerifier.java
@@ -227,8 +227,8 @@ public class IdTokenVerifier {
    *       variable set to true.
    * </ul>
    *
-   * Deprecated, because returns a false-negatives in case of an error while getting public keys
-   * for signature verification. Use {@link IdTokenVerifier.verfyOrThrow(IdToken)} instead.
+   * Deprecated, because returns a false-negatives in case of an error while getting public keys for
+   * signature verification. Use {@link IdTokenVerifier.verfyOrThrow(IdToken)} instead.
    *
    * @param idToken ID token
    * @return {@code true} if verified successfully or {@code false} if failed

--- a/google-oauth-client/src/main/java/com/google/api/client/auth/openidconnect/IdTokenVerifier.java
+++ b/google-oauth-client/src/main/java/com/google/api/client/auth/openidconnect/IdTokenVerifier.java
@@ -69,7 +69,7 @@ import java.util.logging.Logger;
  * href="http://openid.net/specs/openid-connect-basic-1_0-27.html#id.token.validation">ID Token
  * Validation</a>.
  *
- * <p>Call {@link #verify(IdToken)} to verify a ID token. This is a light-weight object, so you may
+ * <p>Call {@link #verify(IdToken)} to verify an ID token. This is a light-weight object, so you may
  * use a new instance for each configuration of expected issuer and trusted client IDs. Sample
  * usage:
  *
@@ -99,7 +99,7 @@ import java.util.logging.Logger;
  * </pre>
  *
  * not recommended: this check can be disabled with OAUTH_CLIENT_SKIP_SIGNATURE environment variable
- * set to true.
+ * set to true. Use {@link #verifyPayload(IdToken)} instead.
  *
  * <p>Note that {@link #verify(IdToken)} only implements a subset of the verification steps, mostly
  * just the MUST steps. Please read <a
@@ -224,11 +224,12 @@ public class IdTokenVerifier {
    *       performed using {@link com.google.api.client.http.javanet.NetHttpTransport} Both
    *       certificate location and transport implementation can be overridden via {@link Builder}
    *       not recommended: this check can be disabled with OAUTH_CLIENT_SKIP_SIGNATURE environment
-   *       variable set to true.
+   *       variable set to true. Use {@link #verifyPayload(IdToken)} instead.
    * </ul>
    *
-   * Deprecated, because returns a false-negatives in case of an error while getting public keys for
-   * signature verification. Use {@link IdTokenVerifier.verfyOrThrow(IdToken)} instead.
+   * Deprecated. This method returns false if network requests to get certificates fail. Use
+   * {@link IdTokenVerifier.verfyOrThrow(IdToken)} instead to differentiate between potentially
+   * retryable network errors and false verification results.
    *
    * @param idToken ID token
    * @return {@code true} if verified successfully or {@code false} if failed


### PR DESCRIPTION
This PR restores the interface of the IdTokenVerifier.verify method to avoid a previous breaking [change](https://github.com/googleapis/google-oauth-java-client/pull/934/files#diff-614b71029b58782f8684645ff56c443eac1ab67b0f6736911ae100d7e3971f8f) that was not released yet. It also deprecates the method as it is no longer recommended to use because it can produce false-negatives if public keys for signature verification are not available. 

Here we add the IdTokenVerifier.verifyOrThrow as an alternative that throws IOExceptions if any issues getting public keys. 