### PR TITLE
chore: setup 1.35.x lts branch

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -14,3 +14,7 @@ branches:
     handleGHRelease: true
     releaseType: java-backport
     branch: 1.33.x
+  - handleGHRelease: true
+    releaseType: java-backport
+    versioning: always-bump-minor
+    branch: 1.35.x

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -54,6 +54,19 @@ branchProtectionRules:
       - dependencies (11)
       - clirr
       - cla/google
+  - pattern: 1.35.x
+    isAdminEnforced: true
+    requiredApprovingReviewCount: 1
+    requiresCodeOwnerReviews: true
+    requiresStrictStatusChecks: false
+    requiredStatusCheckContexts:
+      - checkstyle
+      - units (8)
+      - units (11)
+      - dependencies (8)
+      - dependencies (11)
+      - clirr
+      - cla/google
 permissionRules:
   - team: yoshi-admins
     permission: admin


### PR DESCRIPTION
enable releases