### PR TITLE
chore: checkstyle-test profile name change

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -502,7 +502,7 @@
 
   <profiles>
     <profile>
-      <id>checkstyle</id>
+      <id>checkstyle-tests</id>
       <activation>
         <!-- Checkstyle plugin's dependency now requires Java 11 or higher -->
         <jdk>[11,)</jdk>

--- a/samples/dailymotion-cmdline-sample/pom.xml
+++ b/samples/dailymotion-cmdline-sample/pom.xml
@@ -87,7 +87,7 @@
   </properties>
   <profiles>
     <profile>
-      <id>checkstyle</id>
+      <id>checkstyle-tests</id>
       <activation>
         <!-- Checkstyle plugin's dependency now requires Java 11 or higher -->
         <jdk>[11,)</jdk>

--- a/samples/keycloak-pkce-cmdline-sample/pom.xml
+++ b/samples/keycloak-pkce-cmdline-sample/pom.xml
@@ -87,7 +87,7 @@
   </properties>
   <profiles>
     <profile>
-      <id>checkstyle</id>
+      <id>checkstyle-tests</id>
       <activation>
         <!-- Checkstyle plugin's dependency now requires Java 11 or higher -->
         <jdk>[11,)</jdk>


### PR DESCRIPTION
Renaming the recently added "checkstyle" profile to "checkstyle-tests". This profile name matches java-shared-config
https://github.com/googleapis/java-shared-config/blob/2322b789d9568a1cd8ce4efc04fa11d7ff51c178/java-shared-config/pom.xml#L505C11-L505C27 and we can control the plugin invocation in the same Maven command parameter (`-P=-checkstyle-test`)