### PR TITLE
ci: passing github.token in workflow

### DIFF
--- a/.github/workflows/louhi-tag-release.yaml
+++ b/.github/workflows/louhi-tag-release.yaml
@@ -25,6 +25,8 @@ jobs:
         run: git fetch --tags
       - name: Create additional tags
         shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           SHA=$(git log -1 --format=format:%H)
           PR_NUMBER=$(gh pr list --search "$SHA" --state merged --json number --jq '.[].number')


### PR DESCRIPTION
The workflow failed with the error message:

> gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable. Example:
>  env:
>    GH_TOKEN: ${{ github.token }}
https://github.com/googleapis/google-oauth-java-client/actions/runs/13333566853/job/37243408904
