### PR TITLE
ci: fixing typo in louhi release tag automation

### DIFF
--- a/.github/workflows/louhi-tag-release.yaml
+++ b/.github/workflows/louhi-tag-release.yaml
@@ -34,7 +34,7 @@ jobs:
             echo "Couldn't get pull request number for ${SHA}"
             exit 1
           fi
-          echo "PR {PR_NUMBER} for ${SHA}"
-          TAG_NAME="louhi-{PR_NUMBER}"
+          echo "PR ${PR_NUMBER} for ${SHA}"
+          TAG_NAME="louhi-${PR_NUMBER}"
           git tag $TAG_NAME
           git push origin $TAG_NAME


### PR DESCRIPTION
The latest run didn't substitute the variable correctly: https://github.com/googleapis/google-oauth-java-client/actions/runs/13335726165/job/37250368564

```
PR {PR_NUMBER} for 86a8148d7b6decb8a0b18380111bf77b7e7df763
To https://github.com/googleapis/google-oauth-java-client
 * [new tag]         louhi-{PR_NUMBER} -> louhi-{PR_NUMBER}
```