### PR TITLE
Revert "feat: next release from main branch is 1.39.0 (#1151)"

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -14,7 +14,3 @@ branches:
     handleGHRelease: true
     releaseType: java-backport
     branch: 1.33.x
-  - handleGHRelease: true
-    releaseType: java-backport
-    versioning: always-bump-minor
-    branch: 1.38.x-LTS8

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -54,19 +54,6 @@ branchProtectionRules:
       - dependencies (11)
       - clirr
       - cla/google
-  - pattern: 1.38.x-LTS8
-    isAdminEnforced: true
-    requiredApprovingReviewCount: 1
-    requiresCodeOwnerReviews: true
-    requiresStrictStatusChecks: false
-    requiredStatusCheckContexts:
-      - checkstyle
-      - units (8)
-      - units (11)
-      - dependencies (8)
-      - dependencies (11)
-      - clirr
-      - cla/google
 permissionRules:
   - team: yoshi-admins
     permission: admin


### PR DESCRIPTION
This reverts commit 389afaa270f2953a5afde593e4f04a245775cb63.

kokoro presubmits only run for branches ending in .x
