### PR TITLE
fix: release-please's tagPullRequestNumber

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,6 +1,7 @@
 handleGHRelease: true
 releaseType: java-yoshi
 versioning: always-bump-minor
+tagPullRequestNumber: true
 branches:
   - bumpMinorPreMajor: true
     handleGHRelease: true


### PR DESCRIPTION
With this `tagPullRequestNumber: true` configuration, the Release Please bot will tag the commit SHA with "release-please-<PR number>`.

This information is useful when we create an automation to report the release status back to the pull request.

This configuration change is not exactly a bug fix but "fix:" prefix gives a new release.
