### PR TITLE
chore: replace googleapis-auth with cloud-sdk-auth-team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,7 +5,7 @@
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
 # The @googleapis/cloud-sdk-java-team is the default owner for changes in this repo
-*                        @googleapis/cloud-sdk-java-team @googleapis/googleapis-auth
+*                        @googleapis/cloud-sdk-java-team @googleapis/cloud-sdk-auth-team
 
 
 # The java-samples-reviewers team is the default owner for samples changes

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -87,5 +87,5 @@ permissionRules:
     permission: admin
   - team: yoshi-java
     permission: push
-  - team: googleapis-auth
+  - team: cloud-sdk-auth-team
     permission: admin

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -8,5 +8,5 @@
   "repo_short": "google-oauth-java-client",
   "library_type": "AUTH",
   "distribution_name": "com.google.oauth-client:google-oauth-client",
-  "codeowner_team": "@googleapis/googleapis-auth"
+  "codeowner_team": "@googleapis/cloud-sdk-auth-team"
 }


### PR DESCRIPTION
This PR replaces the old googleapis-auth team with the new cloud-sdk-auth-team.

b/478003109